### PR TITLE
add namespace for svg element

### DIFF
--- a/coffee/epoch.coffee
+++ b/coffee/epoch.coffee
@@ -235,8 +235,10 @@ class Epoch.Chart.SVG extends Epoch.Chart.Base
       @svg = d3.select(@el.get(0)).append('svg')
     else
       @svg = d3.select(document.createElement('svg'))
-    @svg.attr('width', @width).attr('height', @height)
-
+    @svg.attr
+        xmlns: 'http://www.w3.org/2000/svg',
+        width: @width,
+        height: @height
 
 # Base Class for all Canvas based charts.
 class Epoch.Chart.Canvas extends Epoch.Chart.Base


### PR DESCRIPTION
I had difficulty making dynamically-created SVG elements work without the namespace on the `svg` element.
