### PR TITLE
Closes #31; Fixed real-time line plot thickness

### DIFF
--- a/coffee/time/line.coffee
+++ b/coffee/time/line.coffee
@@ -7,7 +7,12 @@ class Epoch.Time.Line extends Epoch.Time.Plot
     styles = @getStyles "g.#{className.replace(/\s/g,'.')} path.line"
     @ctx.fillStyle = styles.fill
     @ctx.strokeStyle = styles.stroke
-    @ctx.lineWidth = styles['stroke-width'].replace('px', '')
+    @ctx.lineWidth = @pixelRatio * styles['stroke-width'].replace('px', '')
+
+  y: ->
+    d3.scale.linear()
+      .domain(@extent((d) -> d.y))
+      .range([@innerHeight() - @pixelRatio/2, @pixelRatio])
 
   # Draws the line chart.
   draw: (delta=0) ->


### PR DESCRIPTION
The plot now takes the device pixel ratio into account to ensure that lines are rendered with the same apparent thickness across displays with different pixel ratios. Also changed the range of the y scale so that partial line segments wouldn't be clipped by the edges of the canvas.
