### PR TITLE
Fixes #22; Fixed Pie Transitions

### DIFF
--- a/coffee/basic/pie.coffee
+++ b/coffee/basic/pie.coffee
@@ -22,6 +22,8 @@ class Epoch.Chart.Pie extends Epoch.Chart.SVG
 
   # Draws the pie chart
   draw: ->
+    @svg.selectAll('.arc').remove()
+
     arcs = @svg.selectAll(".arc")
       .data(@pie(@data), (d) -> d.data.label)
 
@@ -44,5 +46,3 @@ class Epoch.Chart.Pie extends Epoch.Chart.SVG
       .attr("dy", ".35em")
       .style("text-anchor", "middle")
       .text((d) -> d.data.label)
-
-    arcs.exit().remove()

--- a/test/basic/pie.html
+++ b/test/basic/pie.html
@@ -127,7 +127,7 @@
 
         <!-- Test 4 -->
         <div id="test-4" class="test">
-            <h2>4. Pie Tranisition II (<span class="broken">BROKEN</span> - See <a href="https://github.com/fastly/epoch/issues/22" target="_blank">Issue #22</a>)</h2>
+            <h2>4. Pie Tranisition II</h2>
             <p>
                 Correctly transition between set A:
                 <ul>


### PR DESCRIPTION
This addresses an issue where pie charts were getting "out of sync" with the data model and not removing / repositioning old arcs. The fix was to simple select all and remove before rendering the arcs in the SVG. Unfortunately this does little to address #1 since this approach doesn't allow for smooth transitions. Seems better to ensure it is working correctly now and worry about smooth transitions later.
