### PR TITLE
Updated bower.json to valid format

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,12 +1,17 @@
 {
   "name": "epoch",
   "description": "A general purpose, real-time visualization library.",
+  "version": "0.5.2",
+  "main": [
+    "/epoch.0.5.2.min.js",
+    "/epoch.0.5.2.min.css"
+  ],
   "license": "MIT",
   "ignore": [
+    "**/.*",
     "/src",
     "/sass",
-    "/tests",
-    "/.gitignore",
+    "/test",
     "/Cakefile",
     "/CHANGELOG.md",
     "/package.json"
@@ -14,7 +19,15 @@
   "authors": [
     "Ryan Sandor Richards <sandor.richards@gmail.com>"
   ],
-  "homepage": "https://fastly.github.io/epoch/",
+  "keywords": [
+    "fastly",
+    "realtime",
+    "graph",
+    "chart",
+    "stats",
+    "visualization"
+  ],
+  "homepage": "http://fastly.github.io/epoch/",
   "repository": {
     "type": "git",
     "url": "git://github.com/fastly/epoch.git"


### PR DESCRIPTION
Running “bower install epoch” from a non-cached version of the package threw the following warnings:

bower epoch#\*               not-cached git://github.com/fastly/epoch.git#*
bower epoch#\*                  resolve git://github.com/fastly/epoch.git#*
bower epoch#\*                 download https://github.com/fastly/epoch/archive/0.5.2.tar.gz
bower epoch#\*                  extract archive.tar.gz
**bower epoch#\*             invalid-meta epoch is missing "main" entry in bower.json
bower epoch#\*             invalid-meta epoch is missing "ignore" entry in bower.json**
bower epoch#\*                 resolved git://github.com/fastly/epoch.git#0.5.2
bower epoch#~0.5.2             install epoch#0.5.2

I updated the bower.json file to get rid of these warnings. I also added some keywords to improve searchability on bower package search engines.
