### PR TITLE
Add hasOwnProperty guard

### DIFF
--- a/src/basic.coffee
+++ b/src/basic.coffee
@@ -195,7 +195,7 @@ class Epoch.Chart.Plot extends Epoch.Chart.SVG
   # Updates margins in response to a <code>option:margin.*</code> event.
   marginsChanged: ->
     return unless @options.margins?
-    for pos, size of @options.margins
+    for own pos, size of @options.margins
       unless size?
         @margins[pos] = 6
       else

--- a/src/basic/area.coffee
+++ b/src/basic/area.coffee
@@ -10,7 +10,7 @@ class Epoch.Chart.Area extends Epoch.Chart.Plot
   y: ->
     a = []
     for layer in @getVisibleLayers()
-      for k, v of layer.values
+      for own k, v of layer.values
         a[k] += v.y if a[k]?
         a[k] = v.y unless a[k]?
     d3.scale.linear()

--- a/src/basic/bar.coffee
+++ b/src/basic/bar.coffee
@@ -84,7 +84,7 @@ class Epoch.Chart.Bar extends Epoch.Chart.Plot
       for entry in layer.values
         map[entry.x] ?= []
         map[entry.x].push { label: layer.category, y: entry.y, className: className }
-    ({group: k, values: v} for k, v of map)
+    ({group: k, values: v} for own k, v of map)
 
   # Draws the bar char.
   draw: ->

--- a/src/basic/histogram.coffee
+++ b/src/basic/histogram.coffee
@@ -37,7 +37,7 @@ class Epoch.Chart.Histogram extends Epoch.Chart.Bar
         buckets[index] += parseInt point.y
 
       preparedLayer = { values: (buckets.map (d, i) -> {x: parseInt(i) * bucketSize, y: d}) }
-      for k, v of layer
+      for own k, v of layer
         preparedLayer[k] = v unless k == 'values'
 
       prepared.push preparedLayer

--- a/src/core/chart.coffee
+++ b/src/core/chart.coffee
@@ -85,7 +85,7 @@ class Epoch.Chart.Base extends Epoch.Events
   # @param [Object] options Options to set.
   # @event option:* Triggers an option event for each key that was set
   _setManyOptions: (options, prefix='') ->
-    for key, value of options
+    for own key, value of options
       if Epoch.isObject(value)
         @_setManyOptions value, "#{prefix + key}."
       else

--- a/src/core/chart.coffee
+++ b/src/core/chart.coffee
@@ -111,7 +111,7 @@ class Epoch.Chart.Base extends Epoch.Events
   # @overload option(options)
   #   Sets multiple options at once.
   #   @param [Object] options Options to set for the chart.
-  #   @event option:* Triggers an option event for each key that was set. 
+  #   @event option:* Triggers an option event for each key that was set.
   option: ->
     if arguments.length == 0
       @_getAllOptions()
@@ -227,7 +227,7 @@ class Epoch.Chart.Base extends Epoch.Events
     @setData data
     @draw() if draw
 
-  # Draws the chart. Triggers the 'draw' event, subclasses should call super() after drawing to 
+  # Draws the chart. Triggers the 'draw' event, subclasses should call super() after drawing to
   # ensure that the event is triggered.
   # @abstract Must be overriden in child classes to perform chart specific drawing.
   draw: -> @trigger 'draw'

--- a/src/core/util.coffee
+++ b/src/core/util.coffee
@@ -38,7 +38,7 @@ Epoch.isElement = (v) ->
 Epoch.Util.copy = (original) ->
   return null unless original?
   copy = {}
-  copy[k] = v for k, v of original
+  copy[k] = v for own k, v of original
   return copy
 
 # Creates a deep copy of the given options filling in missing defaults.
@@ -46,7 +46,7 @@ Epoch.Util.copy = (original) ->
 # @param [Object] defaults Default values for the options.
 Epoch.Util.defaults = (options, defaults) ->
   result = Epoch.Util.copy(options)
-  for k, v of defaults
+  for own k, v of defaults
     opt = options[k]
     def = defaults[k]
     bothAreObjects = Epoch.isObject(opt) and Epoch.isObject(def)
@@ -75,7 +75,7 @@ Epoch.Util.formatSI = (v, fixed=1, fixIntegers=false) ->
     q = q.toFixed(fixed) unless (q|0) == q and !fixIntegers
     return q
 
-  for i, label of ['K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
+  for own i, label of ['K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
     base = Math.pow(10, ((i|0)+1)*3)
     if v >= base and v < Math.pow(10, ((i|0)+2)*3)
       q = v/base
@@ -93,8 +93,8 @@ Epoch.Util.formatBytes = (v, fixed=1, fix_integers=false) ->
     q = v
     q = q.toFixed(fixed) unless (q % 1) == 0 and !fix_integers
     return "#{q} B"
-    
-  for i, label of ['KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+
+  for own i, label of ['KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
     base = Math.pow(1024, (i|0)+1)
     if v >= base and v < Math.pow(1024, (i|0)+2)
       q = v/base
@@ -178,7 +178,7 @@ class Epoch.Events
   # @param [Object] map A map of event names to callbacks.
   onAll: (map) ->
     return unless Epoch.isObject(map)
-    @on(name, callback) for name, callback of map
+    @on(name, callback) for own name, callback of map
 
   # Removes a specific callback listener or all listeners for a given event.
   # @param [String] name Name of the event.
@@ -198,7 +198,7 @@ class Epoch.Events
     if Epoch.isArray(mapOrList)
       @off(name) for name in mapOrList
     else if Epoch.isObject(mapOrList)
-      @off(name, callback) for name, callback of mapOrList
+      @off(name, callback) for own name, callback of mapOrList
 
   # Triggers an event causing all active listeners to be executed.
   # @param [String] name Name of the event to fire.

--- a/src/data.coffee
+++ b/src/data.coffee
@@ -43,7 +43,7 @@ Epoch.Data.Format.array = (->
   buildLayers = (data, options, mapFn) ->
     result = []
     if Epoch.isArray(data[0])
-      for i, series of data
+      for own i, series of data
         result.push applyLayerLabel({values: series.map(mapFn)}, options, parseInt(i))
     else
       result.push applyLayerLabel({values: data.map(mapFn)}, options, 0)
@@ -63,7 +63,7 @@ Epoch.Data.Format.array = (->
 
   formatPie = (data, options) ->
     result = []
-    for i, v of data
+    for own i, v of data
       return [] unless Epoch.isNumber(data[0])
       result.push applyLayerLabel({ value: v }, options, i)
     return result
@@ -130,7 +130,7 @@ Epoch.Data.Format.tuple = (->
     return [] unless Epoch.isArray(data[0])
     result = []
     if Epoch.isArray(data[0][0])
-      for i, series of data
+      for own i, series of data
         result.push applyLayerLabel({values: series.map(mapFn)}, options, parseInt(i))
     else
       result.push applyLayerLabel({values: data.map(mapFn)}, options, 0)
@@ -199,9 +199,9 @@ Epoch.Data.Format.keyvalue = (->
 
   buildLayers = (data, keys, options, mapFn) ->
     result = []
-    for j, key of keys
+    for own j, key of keys
       values = []
-      for i, d of data
+      for own i, d of data
         values.push mapFn(d, key, parseInt(i))
       result.push applyLayerLabel({ values: values }, options, parseInt(j), keys)
     return result

--- a/src/data.coffee
+++ b/src/data.coffee
@@ -28,7 +28,7 @@ applyLayerLabel = (layer, options, i, keys=[]) ->
 # @option options [Function] time(d, i, startTime) Maps the data to time values for real-time plots given the point and index.
 # @option options [Array] labels Labels to apply to each data layer.
 # @option options [Boolean] autoLabels Apply labels of ascending capital letters to each layer if true.
-# @option options [Number] startTime Unix timestamp used as the starting point for auto acsending times in 
+# @option options [Number] startTime Unix timestamp used as the starting point for auto acsending times in
 #   real-time data formatting.
 Epoch.Data.Format.array = (->
   defaultOptions =
@@ -67,7 +67,7 @@ Epoch.Data.Format.array = (->
       return [] unless Epoch.isNumber(data[0])
       result.push applyLayerLabel({ value: v }, options, i)
     return result
-        
+
   format = (data=[], options={}) ->
     return [] unless Epoch.isArray(data) and data.length > 0
     opt = Epoch.Util.defaults options, defaultOptions
@@ -168,7 +168,7 @@ Epoch.Data.Format.tuple = (->
 # It then extracts the value for each key across each of the objects in the array
 # to produce multi-layer plot data of the given chart type. Note that this formatter
 # also can be passed an <code>x</code> or <code>time</code> option as a string that
-# allows the programmer specify a key to use for the value of the first component 
+# allows the programmer specify a key to use for the value of the first component
 # (x or time) of each resulting layer value.
 #
 # Note that this format does not work with basic pie charts nor real-time gauge charts.
@@ -184,7 +184,7 @@ Epoch.Data.Format.tuple = (->
 # @option options [Array] labels Labels to apply to each data layer.
 # @option options [Boolean] autoLabels Apply labels of ascending capital letters to each layer if true.
 # @option options [Boolean] keyLabels Apply labels using the keys passed to the formatter (defaults to true).
-# @option options [Number] startTime Unix timestamp used as the starting point for auto acsending times in 
+# @option options [Number] startTime Unix timestamp used as the starting point for auto acsending times in
 #   real-time data formatting.
 Epoch.Data.Format.keyvalue = (->
   defaultOptions =

--- a/src/time.coffee
+++ b/src/time.coffee
@@ -142,7 +142,7 @@ class Epoch.Time.Plot extends Epoch.Chart.Canvas
     @svg.selectAll('.axis').remove()
     @_prepareTimeAxes()
     @_prepareRangeAxes()
-    
+
   # Works exactly as in Epoch.Chart.Base with the addition of truncating value arrays
   # to that of the historySize defined in the chart's options.
   _annotateLayers: (prepared) ->
@@ -265,7 +265,7 @@ class Epoch.Time.Plot extends Epoch.Chart.Canvas
 
   # This method will remove the first incoming entry from the visualization's queue
   # and shift it into the working set (aka window). It then starts the animating the
-  # transition of the element into the visualization. 
+  # transition of the element into the visualization.
   # @event transition:start in the case that animation is actually started.
   _startTransition: ->
     return if @animation.active == true or @_queue.length == 0

--- a/src/time.coffee
+++ b/src/time.coffee
@@ -147,7 +147,7 @@ class Epoch.Time.Plot extends Epoch.Chart.Canvas
   # to that of the historySize defined in the chart's options.
   _annotateLayers: (prepared) ->
     data = []
-    for i, layer of prepared
+    for own i, layer of prepared
       copy = Epoch.Util.copy(layer)
       start = Math.max(0, layer.values.length - @options.historySize)
       copy.values = layer.values.slice(start)
@@ -352,7 +352,7 @@ class Epoch.Time.Plot extends Epoch.Chart.Canvas
   _shift: ->
     @trigger 'before:shift'
     entry = @_queue.shift()
-    layer.values.push(entry[i]) for i, layer of @data
+    layer.values.push(entry[i]) for own i, layer of @data
     @_updateTicks(entry[0].time)
     @_transitionRangeAxes()
     @trigger 'after:shift'
@@ -535,7 +535,7 @@ class Epoch.Time.Plot extends Epoch.Chart.Canvas
   # Updates margins in response to an <code>option.margins.*</code> event.
   marginsChanged: ->
     return unless @options.margins?
-    for pos, size of @options.margins
+    for own pos, size of @options.margins
       unless size?
         @margins[pos] = 6
       else
@@ -566,7 +566,7 @@ class Epoch.Time.Stack extends Epoch.Time.Plot
   # @param [Array] layers Layers to stack.
   _prepareLayers: (layers) ->
     y0 = 0
-    for i, d of layers
+    for own i, d of layers
       continue unless @data[i].visible
       d.y0 = y0
       y0 += d.y

--- a/src/time/heatmap.coffee
+++ b/src/time/heatmap.coffee
@@ -71,7 +71,7 @@ class Epoch.Time.Heatmap extends Epoch.Time.Plot
     # Bucket size = (Range[1] - Range[0]) / number of buckets
     bucketSize = (@options.bucketRange[1] - @options.bucketRange[0]) / @options.buckets
 
-    for value, count of entry.histogram
+    for own value, count of entry.histogram
       index = parseInt((value - @options.bucketRange[0]) / bucketSize)
 
       # Remove outliers from the preprared buckets if instructed to do so
@@ -174,7 +174,7 @@ class Epoch.Time.Heatmap extends Epoch.Time.Plot
 
     for layer in @getVisibleLayers()
       entry = @_getBuckets( layer.values[entryIndex] )
-      for bucket, count of entry.buckets
+      for own bucket, count of entry.buckets
         bucketTotals[bucket] += count
       maxTotal += entry.max
       styles = @getStyles ".#{layer.className.split(' ').join('.')} rect.bucket"
@@ -187,7 +187,7 @@ class Epoch.Time.Heatmap extends Epoch.Time.Plot
 
     j = @options.buckets
 
-    for bucket, sum of bucketTotals
+    for own bucket, sum of bucketTotals
       color = @_avgLab(entries, bucket)
       max = 0
       for entry in entries
@@ -213,7 +213,7 @@ class Epoch.Time.Heatmap extends Epoch.Time.Plot
       continue unless entry.buckets[bucket]?
       total += entry.buckets[bucket]
 
-    for i, entry of entries
+    for own i, entry of entries
       if entry.buckets[bucket]?
         value = entry.buckets[bucket]|0
       else


### PR DESCRIPTION
@duretti @rsandor @jadeapplegate @oso-mate

CoffeeScript's `for own x, y of z` adds a `hasOwnProperty` guard to the iteration. That's important in general, but particularly when `Array.prototype` has been extended.