### PR TITLE
Fixes rendering bug in Epoch.Time.Heatmap

### DIFF
--- a/src/core/util.coffee
+++ b/src/core/util.coffee
@@ -32,6 +32,12 @@ Epoch.isElement = (v) ->
   else
     v? and Epoch.isObject(v) and v.nodeType == 1 and Epoch.isString(v.nodeName)
 
+# Determines if a given value is a non-empty array.
+# @param v Value to test.
+# @return [Boolean] <code>true</code> if the given value is an array with at least one element.
+Epoch.isNonEmptyArray = (v) ->
+  Epoch.isArray(v) and v.length > 0
+
 # Generates shallow copy of an object.
 # @return A shallow copy of the given object.
 # @param [Object] original Object for which to make the shallow copy.

--- a/src/data.coffee
+++ b/src/data.coffee
@@ -69,7 +69,7 @@ Epoch.Data.Format.array = (->
     return result
 
   format = (data=[], options={}) ->
-    return [] unless Epoch.isArray(data) and data.length > 0
+    return [] unless Epoch.isNonEmptyArray(data)
     opt = Epoch.Util.defaults options, defaultOptions
 
     if opt.type == 'time.heatmap'
@@ -137,7 +137,7 @@ Epoch.Data.Format.tuple = (->
     return result
 
   format = (data=[], options={}) ->
-    return [] unless Epoch.isArray(data) and data.length > 0
+    return [] unless Epoch.isNonEmptyArray(data)
     opt = Epoch.Util.defaults options, defaultOptions
 
     if opt.type == 'pie' or opt.type == 'time.heatmap' or opt.type == 'time.gauge'
@@ -224,7 +224,7 @@ Epoch.Data.Format.keyvalue = (->
       value
 
   format = (data=[], keys=[], options={}) ->
-    return [] unless Epoch.isArray(data) and data.length > 0 and keys.length > 0
+    return [] unless Epoch.isNonEmptyArray(data) and Epoch.isNonEmptyArray(keys)
     opt = Epoch.Util.defaults options, defaultOptions
 
     if opt.type == 'pie' or opt.type == 'time.gauge'
@@ -237,7 +237,7 @@ Epoch.Data.Format.keyvalue = (->
       formatBasicPlot data, keys, opt
 
   format.entry = (datum, keys=[], options={}) ->
-    return [] unless datum? and keys? and keys.length > 0
+    return [] unless datum? and Epoch.isNonEmptyArray(keys)
     unless options.startTime?
      options.startTime = parseInt(new Date().getTime() / 1000)
     (layer.values[0] for layer in format([datum], keys, options))
@@ -258,7 +258,7 @@ Epoch.data = (formatter, args...) ->
 # Abstracted here because we'd like to allow models and indivisual charts to
 # perform this action depending on the context.
 Epoch.Data.formatData = (data=[], type, dataFormat) ->
-  return data unless dataFormat? and data.length > 0
+  return data unless Epoch.isNonEmptyArray(data)
 
   if Epoch.isString(dataFormat)
     opts = { type: type }

--- a/src/time.coffee
+++ b/src/time.coffee
@@ -196,7 +196,7 @@ class Epoch.Time.Plot extends Epoch.Chart.Canvas
     @topAxis.selectAll('.tick').remove() if @topAxis?
 
     for layer in @data
-      continue unless layer.values? and layer.values.length > 0
+      continue unless Epoch.isNonEmptyArray(layer.values)
       [i, k] = [@options.windowSize-1, layer.values.length-1]
       while i >= 0 and k >= 0
         @_pushTick i, layer.values[k].time, false, true

--- a/src/time/bar.coffee
+++ b/src/time/bar.coffee
@@ -29,7 +29,7 @@ class Epoch.Time.Bar extends Epoch.Time.Stack
     [y, w] = [@y(), @w()]
 
     for layer in @getVisibleLayers()
-      continue unless layer.values.length > 0
+      continue unless Epoch.isNonEmptyArray(layer.values)
       @setStyles(layer.className)
 
       [i, k, trans] = [@options.windowSize, layer.values.length, @inTransition()]
@@ -43,5 +43,5 @@ class Epoch.Time.Bar extends Epoch.Time.Stack
 
         @ctx.fillRect.apply(@ctx, args)
         @ctx.strokeRect.apply(@ctx, args)
-        
+
     super()

--- a/src/time/heatmap.coffee
+++ b/src/time/heatmap.coffee
@@ -141,7 +141,8 @@ class Epoch.Time.Heatmap extends Epoch.Time.Plot
 
   # Redraws the entire heatmap for the current data.
   redraw: ->
-    return unless Epoch.isArray(@data) and @data.length > 0 and @data[0].length > 0
+    return unless Epoch.isArray(@data) and @data.length > 0 and @data[0].values? and @data[0].values.length > 0
+
     entryIndex = @data[0].values.length
     drawColumn = @options.windowSize
 

--- a/src/time/heatmap.coffee
+++ b/src/time/heatmap.coffee
@@ -141,8 +141,7 @@ class Epoch.Time.Heatmap extends Epoch.Time.Plot
 
   # Redraws the entire heatmap for the current data.
   redraw: ->
-    return unless Epoch.isArray(@data) and @data.length > 0 and @data[0].values? and @data[0].values.length > 0
-
+    return unless Epoch.isNonEmptyArray(@data) and Epoch.isNonEmptyArray(@data[0].values)
     entryIndex = @data[0].values.length
     drawColumn = @options.windowSize
 

--- a/src/time/line.coffee
+++ b/src/time/line.coffee
@@ -19,7 +19,7 @@ class Epoch.Time.Line extends Epoch.Time.Plot
     [y, w] = [@y(), @w()]
 
     for layer in @getVisibleLayers()
-      continue unless layer.values.length > 0
+      continue unless Epoch.isNonEmptyArray(layer.values)
       @setStyles(layer.className)
       @ctx.beginPath()
 

--- a/tests/unit/core/is.coffee
+++ b/tests/unit/core/is.coffee
@@ -68,3 +68,18 @@ describe 'Epoch.Util', ->
       assert.notOk Epoch.isElement({})
       assert.notOk Epoch.isElement([])
       assert.notOk Epoch.isElement(->)
+
+  describe 'isNonEmptyArray', ->
+    it 'should return true given a non-empty array', ->
+      assert.ok Epoch.isNonEmptyArray([1])
+      assert.ok Epoch.isNonEmptyArray([1, 3])
+      assert.ok Epoch.isNonEmptyArray(["foo", 4, "bar"])
+
+    it 'should return false given a non-array', ->
+      assert.notOk Epoch.isNonEmptyArray(2)
+      assert.notOk Epoch.isNonEmptyArray("five")
+      assert.notOk Epoch.isNonEmptyArray({})
+      assert.notOk Epoch.isNonEmptyArray(->)
+
+    it 'should return false given an empty array', ->
+      assert.notOk Epoch.isNonEmptyArray([])

--- a/tests/unit/core/is.coffee
+++ b/tests/unit/core/is.coffee
@@ -81,5 +81,8 @@ describe 'Epoch.Util', ->
       assert.notOk Epoch.isNonEmptyArray({})
       assert.notOk Epoch.isNonEmptyArray(->)
 
+    it 'should return false given a null value', ->
+      assert.notOk Epoch.isNonEmptyArray(null)
+
     it 'should return false given an empty array', ->
       assert.notOk Epoch.isNonEmptyArray([])


### PR DESCRIPTION
At the top of the `Epoch.Time.Heatmap.redraw` there is a series of checks that ensures the chart has data before fully redrawing chart. It was erroneously inspecting the `@data` member when ensuring that the first layer had actual values to display.