### PR TITLE
Cleaned up epoch.min.css for readibility

### DIFF
--- a/dist/css/epoch.min.css
+++ b/dist/css/epoch.min.css
@@ -1,1 +1,1486 @@
-.epoch .axis path,.epoch .axis line{shape-rendering:crispEdges}.epoch .axis.canvas .tick line{shape-rendering:geometricPrecision}div#_canvas_css_reference{width:0;height:0;position:absolute;top:-1000px;left:-1000px}div#_canvas_css_reference svg{position:absolute;width:0;height:0;top:-1000px;left:-1000px}.epoch{font-family:"Helvetica Neue", Helvetica, Arial, sans-serif;font-size:12pt}.epoch .axis path,.epoch .axis line{fill:transparent;stroke:#000}.epoch .axis .tick text{font-size:9pt}.epoch .line{fill:transparent;stroke-width:2px}.epoch.sparklines .line{stroke-width:1px}.epoch .area{stroke:transparent}.epoch .arc.pie{stroke:#fff;stroke-width:1.5px}.epoch .arc.pie text{stroke:transparent;fill:white;font-size:9pt}.epoch .gauge-labels .value{text-anchor:middle;font-size:140%;fill:#666}.epoch.gauge-tiny{width:120px;height:90px}.epoch.gauge-tiny .gauge-labels .value{font-size:80%}.epoch.gauge-tiny .gauge .arc.outer{stroke-width:2px}.epoch.gauge-small{width:180px;height:135px}.epoch.gauge-small .gauge-labels .value{font-size:120%}.epoch.gauge-small .gauge .arc.outer{stroke-width:3px}.epoch.gauge-medium{width:240px;height:180px}.epoch.gauge-medium .gauge .arc.outer{stroke-width:3px}.epoch.gauge-large{width:320px;height:240px}.epoch.gauge-large .gauge-labels .value{font-size:180%}.epoch .gauge .arc.outer{stroke-width:4px;stroke:#666}.epoch .gauge .arc.inner{stroke-width:1px;stroke:#555}.epoch .gauge .tick{stroke-width:1px;stroke:#555}.epoch .gauge .needle{fill:orange}.epoch .gauge .needle-base{fill:#666}.epoch div.ref.category1,.epoch.category10 div.ref.category1{background-color:#1f77b4}.epoch .category1 .line,.epoch.category10 .category1 .line{stroke:#1f77b4}.epoch .category1 .area,.epoch .category1 .dot,.epoch.category10 .category1 .area,.epoch.category10 .category1 .dot{fill:#1f77b4;stroke:transparent}.epoch .arc.category1 path,.epoch.category10 .arc.category1 path{fill:#1f77b4}.epoch .bar.category1,.epoch.category10 .bar.category1{fill:#1f77b4}.epoch div.ref.category2,.epoch.category10 div.ref.category2{background-color:#ff7f0e}.epoch .category2 .line,.epoch.category10 .category2 .line{stroke:#ff7f0e}.epoch .category2 .area,.epoch .category2 .dot,.epoch.category10 .category2 .area,.epoch.category10 .category2 .dot{fill:#ff7f0e;stroke:transparent}.epoch .arc.category2 path,.epoch.category10 .arc.category2 path{fill:#ff7f0e}.epoch .bar.category2,.epoch.category10 .bar.category2{fill:#ff7f0e}.epoch div.ref.category3,.epoch.category10 div.ref.category3{background-color:#2ca02c}.epoch .category3 .line,.epoch.category10 .category3 .line{stroke:#2ca02c}.epoch .category3 .area,.epoch .category3 .dot,.epoch.category10 .category3 .area,.epoch.category10 .category3 .dot{fill:#2ca02c;stroke:transparent}.epoch .arc.category3 path,.epoch.category10 .arc.category3 path{fill:#2ca02c}.epoch .bar.category3,.epoch.category10 .bar.category3{fill:#2ca02c}.epoch div.ref.category4,.epoch.category10 div.ref.category4{background-color:#d62728}.epoch .category4 .line,.epoch.category10 .category4 .line{stroke:#d62728}.epoch .category4 .area,.epoch .category4 .dot,.epoch.category10 .category4 .area,.epoch.category10 .category4 .dot{fill:#d62728;stroke:transparent}.epoch .arc.category4 path,.epoch.category10 .arc.category4 path{fill:#d62728}.epoch .bar.category4,.epoch.category10 .bar.category4{fill:#d62728}.epoch div.ref.category5,.epoch.category10 div.ref.category5{background-color:#9467bd}.epoch .category5 .line,.epoch.category10 .category5 .line{stroke:#9467bd}.epoch .category5 .area,.epoch .category5 .dot,.epoch.category10 .category5 .area,.epoch.category10 .category5 .dot{fill:#9467bd;stroke:transparent}.epoch .arc.category5 path,.epoch.category10 .arc.category5 path{fill:#9467bd}.epoch .bar.category5,.epoch.category10 .bar.category5{fill:#9467bd}.epoch div.ref.category6,.epoch.category10 div.ref.category6{background-color:#8c564b}.epoch .category6 .line,.epoch.category10 .category6 .line{stroke:#8c564b}.epoch .category6 .area,.epoch .category6 .dot,.epoch.category10 .category6 .area,.epoch.category10 .category6 .dot{fill:#8c564b;stroke:transparent}.epoch .arc.category6 path,.epoch.category10 .arc.category6 path{fill:#8c564b}.epoch .bar.category6,.epoch.category10 .bar.category6{fill:#8c564b}.epoch div.ref.category7,.epoch.category10 div.ref.category7{background-color:#e377c2}.epoch .category7 .line,.epoch.category10 .category7 .line{stroke:#e377c2}.epoch .category7 .area,.epoch .category7 .dot,.epoch.category10 .category7 .area,.epoch.category10 .category7 .dot{fill:#e377c2;stroke:transparent}.epoch .arc.category7 path,.epoch.category10 .arc.category7 path{fill:#e377c2}.epoch .bar.category7,.epoch.category10 .bar.category7{fill:#e377c2}.epoch div.ref.category8,.epoch.category10 div.ref.category8{background-color:#7f7f7f}.epoch .category8 .line,.epoch.category10 .category8 .line{stroke:#7f7f7f}.epoch .category8 .area,.epoch .category8 .dot,.epoch.category10 .category8 .area,.epoch.category10 .category8 .dot{fill:#7f7f7f;stroke:transparent}.epoch .arc.category8 path,.epoch.category10 .arc.category8 path{fill:#7f7f7f}.epoch .bar.category8,.epoch.category10 .bar.category8{fill:#7f7f7f}.epoch div.ref.category9,.epoch.category10 div.ref.category9{background-color:#bcbd22}.epoch .category9 .line,.epoch.category10 .category9 .line{stroke:#bcbd22}.epoch .category9 .area,.epoch .category9 .dot,.epoch.category10 .category9 .area,.epoch.category10 .category9 .dot{fill:#bcbd22;stroke:transparent}.epoch .arc.category9 path,.epoch.category10 .arc.category9 path{fill:#bcbd22}.epoch .bar.category9,.epoch.category10 .bar.category9{fill:#bcbd22}.epoch div.ref.category10,.epoch.category10 div.ref.category10{background-color:#17becf}.epoch .category10 .line,.epoch.category10 .category10 .line{stroke:#17becf}.epoch .category10 .area,.epoch .category10 .dot,.epoch.category10 .category10 .area,.epoch.category10 .category10 .dot{fill:#17becf;stroke:transparent}.epoch .arc.category10 path,.epoch.category10 .arc.category10 path{fill:#17becf}.epoch .bar.category10,.epoch.category10 .bar.category10{fill:#17becf}.epoch.category20 div.ref.category1{background-color:#1f77b4}.epoch.category20 .category1 .line{stroke:#1f77b4}.epoch.category20 .category1 .area,.epoch.category20 .category1 .dot{fill:#1f77b4;stroke:transparent}.epoch.category20 .arc.category1 path{fill:#1f77b4}.epoch.category20 .bar.category1{fill:#1f77b4}.epoch.category20 div.ref.category2{background-color:#aec7e8}.epoch.category20 .category2 .line{stroke:#aec7e8}.epoch.category20 .category2 .area,.epoch.category20 .category2 .dot{fill:#aec7e8;stroke:transparent}.epoch.category20 .arc.category2 path{fill:#aec7e8}.epoch.category20 .bar.category2{fill:#aec7e8}.epoch.category20 div.ref.category3{background-color:#ff7f0e}.epoch.category20 .category3 .line{stroke:#ff7f0e}.epoch.category20 .category3 .area,.epoch.category20 .category3 .dot{fill:#ff7f0e;stroke:transparent}.epoch.category20 .arc.category3 path{fill:#ff7f0e}.epoch.category20 .bar.category3{fill:#ff7f0e}.epoch.category20 div.ref.category4{background-color:#ffbb78}.epoch.category20 .category4 .line{stroke:#ffbb78}.epoch.category20 .category4 .area,.epoch.category20 .category4 .dot{fill:#ffbb78;stroke:transparent}.epoch.category20 .arc.category4 path{fill:#ffbb78}.epoch.category20 .bar.category4{fill:#ffbb78}.epoch.category20 div.ref.category5{background-color:#2ca02c}.epoch.category20 .category5 .line{stroke:#2ca02c}.epoch.category20 .category5 .area,.epoch.category20 .category5 .dot{fill:#2ca02c;stroke:transparent}.epoch.category20 .arc.category5 path{fill:#2ca02c}.epoch.category20 .bar.category5{fill:#2ca02c}.epoch.category20 div.ref.category6{background-color:#98df8a}.epoch.category20 .category6 .line{stroke:#98df8a}.epoch.category20 .category6 .area,.epoch.category20 .category6 .dot{fill:#98df8a;stroke:transparent}.epoch.category20 .arc.category6 path{fill:#98df8a}.epoch.category20 .bar.category6{fill:#98df8a}.epoch.category20 div.ref.category7{background-color:#d62728}.epoch.category20 .category7 .line{stroke:#d62728}.epoch.category20 .category7 .area,.epoch.category20 .category7 .dot{fill:#d62728;stroke:transparent}.epoch.category20 .arc.category7 path{fill:#d62728}.epoch.category20 .bar.category7{fill:#d62728}.epoch.category20 div.ref.category8{background-color:#ff9896}.epoch.category20 .category8 .line{stroke:#ff9896}.epoch.category20 .category8 .area,.epoch.category20 .category8 .dot{fill:#ff9896;stroke:transparent}.epoch.category20 .arc.category8 path{fill:#ff9896}.epoch.category20 .bar.category8{fill:#ff9896}.epoch.category20 div.ref.category9{background-color:#9467bd}.epoch.category20 .category9 .line{stroke:#9467bd}.epoch.category20 .category9 .area,.epoch.category20 .category9 .dot{fill:#9467bd;stroke:transparent}.epoch.category20 .arc.category9 path{fill:#9467bd}.epoch.category20 .bar.category9{fill:#9467bd}.epoch.category20 div.ref.category10{background-color:#c5b0d5}.epoch.category20 .category10 .line{stroke:#c5b0d5}.epoch.category20 .category10 .area,.epoch.category20 .category10 .dot{fill:#c5b0d5;stroke:transparent}.epoch.category20 .arc.category10 path{fill:#c5b0d5}.epoch.category20 .bar.category10{fill:#c5b0d5}.epoch.category20 div.ref.category11{background-color:#8c564b}.epoch.category20 .category11 .line{stroke:#8c564b}.epoch.category20 .category11 .area,.epoch.category20 .category11 .dot{fill:#8c564b;stroke:transparent}.epoch.category20 .arc.category11 path{fill:#8c564b}.epoch.category20 .bar.category11{fill:#8c564b}.epoch.category20 div.ref.category12{background-color:#c49c94}.epoch.category20 .category12 .line{stroke:#c49c94}.epoch.category20 .category12 .area,.epoch.category20 .category12 .dot{fill:#c49c94;stroke:transparent}.epoch.category20 .arc.category12 path{fill:#c49c94}.epoch.category20 .bar.category12{fill:#c49c94}.epoch.category20 div.ref.category13{background-color:#e377c2}.epoch.category20 .category13 .line{stroke:#e377c2}.epoch.category20 .category13 .area,.epoch.category20 .category13 .dot{fill:#e377c2;stroke:transparent}.epoch.category20 .arc.category13 path{fill:#e377c2}.epoch.category20 .bar.category13{fill:#e377c2}.epoch.category20 div.ref.category14{background-color:#f7b6d2}.epoch.category20 .category14 .line{stroke:#f7b6d2}.epoch.category20 .category14 .area,.epoch.category20 .category14 .dot{fill:#f7b6d2;stroke:transparent}.epoch.category20 .arc.category14 path{fill:#f7b6d2}.epoch.category20 .bar.category14{fill:#f7b6d2}.epoch.category20 div.ref.category15{background-color:#7f7f7f}.epoch.category20 .category15 .line{stroke:#7f7f7f}.epoch.category20 .category15 .area,.epoch.category20 .category15 .dot{fill:#7f7f7f;stroke:transparent}.epoch.category20 .arc.category15 path{fill:#7f7f7f}.epoch.category20 .bar.category15{fill:#7f7f7f}.epoch.category20 div.ref.category16{background-color:#c7c7c7}.epoch.category20 .category16 .line{stroke:#c7c7c7}.epoch.category20 .category16 .area,.epoch.category20 .category16 .dot{fill:#c7c7c7;stroke:transparent}.epoch.category20 .arc.category16 path{fill:#c7c7c7}.epoch.category20 .bar.category16{fill:#c7c7c7}.epoch.category20 div.ref.category17{background-color:#bcbd22}.epoch.category20 .category17 .line{stroke:#bcbd22}.epoch.category20 .category17 .area,.epoch.category20 .category17 .dot{fill:#bcbd22;stroke:transparent}.epoch.category20 .arc.category17 path{fill:#bcbd22}.epoch.category20 .bar.category17{fill:#bcbd22}.epoch.category20 div.ref.category18{background-color:#dbdb8d}.epoch.category20 .category18 .line{stroke:#dbdb8d}.epoch.category20 .category18 .area,.epoch.category20 .category18 .dot{fill:#dbdb8d;stroke:transparent}.epoch.category20 .arc.category18 path{fill:#dbdb8d}.epoch.category20 .bar.category18{fill:#dbdb8d}.epoch.category20 div.ref.category19{background-color:#17becf}.epoch.category20 .category19 .line{stroke:#17becf}.epoch.category20 .category19 .area,.epoch.category20 .category19 .dot{fill:#17becf;stroke:transparent}.epoch.category20 .arc.category19 path{fill:#17becf}.epoch.category20 .bar.category19{fill:#17becf}.epoch.category20 div.ref.category20{background-color:#9edae5}.epoch.category20 .category20 .line{stroke:#9edae5}.epoch.category20 .category20 .area,.epoch.category20 .category20 .dot{fill:#9edae5;stroke:transparent}.epoch.category20 .arc.category20 path{fill:#9edae5}.epoch.category20 .bar.category20{fill:#9edae5}.epoch.category20b div.ref.category1{background-color:#393b79}.epoch.category20b .category1 .line{stroke:#393b79}.epoch.category20b .category1 .area,.epoch.category20b .category1 .dot{fill:#393b79;stroke:transparent}.epoch.category20b .arc.category1 path{fill:#393b79}.epoch.category20b .bar.category1{fill:#393b79}.epoch.category20b div.ref.category2{background-color:#5254a3}.epoch.category20b .category2 .line{stroke:#5254a3}.epoch.category20b .category2 .area,.epoch.category20b .category2 .dot{fill:#5254a3;stroke:transparent}.epoch.category20b .arc.category2 path{fill:#5254a3}.epoch.category20b .bar.category2{fill:#5254a3}.epoch.category20b div.ref.category3{background-color:#6b6ecf}.epoch.category20b .category3 .line{stroke:#6b6ecf}.epoch.category20b .category3 .area,.epoch.category20b .category3 .dot{fill:#6b6ecf;stroke:transparent}.epoch.category20b .arc.category3 path{fill:#6b6ecf}.epoch.category20b .bar.category3{fill:#6b6ecf}.epoch.category20b div.ref.category4{background-color:#9c9ede}.epoch.category20b .category4 .line{stroke:#9c9ede}.epoch.category20b .category4 .area,.epoch.category20b .category4 .dot{fill:#9c9ede;stroke:transparent}.epoch.category20b .arc.category4 path{fill:#9c9ede}.epoch.category20b .bar.category4{fill:#9c9ede}.epoch.category20b div.ref.category5{background-color:#637939}.epoch.category20b .category5 .line{stroke:#637939}.epoch.category20b .category5 .area,.epoch.category20b .category5 .dot{fill:#637939;stroke:transparent}.epoch.category20b .arc.category5 path{fill:#637939}.epoch.category20b .bar.category5{fill:#637939}.epoch.category20b div.ref.category6{background-color:#8ca252}.epoch.category20b .category6 .line{stroke:#8ca252}.epoch.category20b .category6 .area,.epoch.category20b .category6 .dot{fill:#8ca252;stroke:transparent}.epoch.category20b .arc.category6 path{fill:#8ca252}.epoch.category20b .bar.category6{fill:#8ca252}.epoch.category20b div.ref.category7{background-color:#b5cf6b}.epoch.category20b .category7 .line{stroke:#b5cf6b}.epoch.category20b .category7 .area,.epoch.category20b .category7 .dot{fill:#b5cf6b;stroke:transparent}.epoch.category20b .arc.category7 path{fill:#b5cf6b}.epoch.category20b .bar.category7{fill:#b5cf6b}.epoch.category20b div.ref.category8{background-color:#cedb9c}.epoch.category20b .category8 .line{stroke:#cedb9c}.epoch.category20b .category8 .area,.epoch.category20b .category8 .dot{fill:#cedb9c;stroke:transparent}.epoch.category20b .arc.category8 path{fill:#cedb9c}.epoch.category20b .bar.category8{fill:#cedb9c}.epoch.category20b div.ref.category9{background-color:#8c6d31}.epoch.category20b .category9 .line{stroke:#8c6d31}.epoch.category20b .category9 .area,.epoch.category20b .category9 .dot{fill:#8c6d31;stroke:transparent}.epoch.category20b .arc.category9 path{fill:#8c6d31}.epoch.category20b .bar.category9{fill:#8c6d31}.epoch.category20b div.ref.category10{background-color:#bd9e39}.epoch.category20b .category10 .line{stroke:#bd9e39}.epoch.category20b .category10 .area,.epoch.category20b .category10 .dot{fill:#bd9e39;stroke:transparent}.epoch.category20b .arc.category10 path{fill:#bd9e39}.epoch.category20b .bar.category10{fill:#bd9e39}.epoch.category20b div.ref.category11{background-color:#e7ba52}.epoch.category20b .category11 .line{stroke:#e7ba52}.epoch.category20b .category11 .area,.epoch.category20b .category11 .dot{fill:#e7ba52;stroke:transparent}.epoch.category20b .arc.category11 path{fill:#e7ba52}.epoch.category20b .bar.category11{fill:#e7ba52}.epoch.category20b div.ref.category12{background-color:#e7cb94}.epoch.category20b .category12 .line{stroke:#e7cb94}.epoch.category20b .category12 .area,.epoch.category20b .category12 .dot{fill:#e7cb94;stroke:transparent}.epoch.category20b .arc.category12 path{fill:#e7cb94}.epoch.category20b .bar.category12{fill:#e7cb94}.epoch.category20b div.ref.category13{background-color:#843c39}.epoch.category20b .category13 .line{stroke:#843c39}.epoch.category20b .category13 .area,.epoch.category20b .category13 .dot{fill:#843c39;stroke:transparent}.epoch.category20b .arc.category13 path{fill:#843c39}.epoch.category20b .bar.category13{fill:#843c39}.epoch.category20b div.ref.category14{background-color:#ad494a}.epoch.category20b .category14 .line{stroke:#ad494a}.epoch.category20b .category14 .area,.epoch.category20b .category14 .dot{fill:#ad494a;stroke:transparent}.epoch.category20b .arc.category14 path{fill:#ad494a}.epoch.category20b .bar.category14{fill:#ad494a}.epoch.category20b div.ref.category15{background-color:#d6616b}.epoch.category20b .category15 .line{stroke:#d6616b}.epoch.category20b .category15 .area,.epoch.category20b .category15 .dot{fill:#d6616b;stroke:transparent}.epoch.category20b .arc.category15 path{fill:#d6616b}.epoch.category20b .bar.category15{fill:#d6616b}.epoch.category20b div.ref.category16{background-color:#e7969c}.epoch.category20b .category16 .line{stroke:#e7969c}.epoch.category20b .category16 .area,.epoch.category20b .category16 .dot{fill:#e7969c;stroke:transparent}.epoch.category20b .arc.category16 path{fill:#e7969c}.epoch.category20b .bar.category16{fill:#e7969c}.epoch.category20b div.ref.category17{background-color:#7b4173}.epoch.category20b .category17 .line{stroke:#7b4173}.epoch.category20b .category17 .area,.epoch.category20b .category17 .dot{fill:#7b4173;stroke:transparent}.epoch.category20b .arc.category17 path{fill:#7b4173}.epoch.category20b .bar.category17{fill:#7b4173}.epoch.category20b div.ref.category18{background-color:#a55194}.epoch.category20b .category18 .line{stroke:#a55194}.epoch.category20b .category18 .area,.epoch.category20b .category18 .dot{fill:#a55194;stroke:transparent}.epoch.category20b .arc.category18 path{fill:#a55194}.epoch.category20b .bar.category18{fill:#a55194}.epoch.category20b div.ref.category19{background-color:#ce6dbd}.epoch.category20b .category19 .line{stroke:#ce6dbd}.epoch.category20b .category19 .area,.epoch.category20b .category19 .dot{fill:#ce6dbd;stroke:transparent}.epoch.category20b .arc.category19 path{fill:#ce6dbd}.epoch.category20b .bar.category19{fill:#ce6dbd}.epoch.category20b div.ref.category20{background-color:#de9ed6}.epoch.category20b .category20 .line{stroke:#de9ed6}.epoch.category20b .category20 .area,.epoch.category20b .category20 .dot{fill:#de9ed6;stroke:transparent}.epoch.category20b .arc.category20 path{fill:#de9ed6}.epoch.category20b .bar.category20{fill:#de9ed6}.epoch.category20c div.ref.category1{background-color:#3182bd}.epoch.category20c .category1 .line{stroke:#3182bd}.epoch.category20c .category1 .area,.epoch.category20c .category1 .dot{fill:#3182bd;stroke:transparent}.epoch.category20c .arc.category1 path{fill:#3182bd}.epoch.category20c .bar.category1{fill:#3182bd}.epoch.category20c div.ref.category2{background-color:#6baed6}.epoch.category20c .category2 .line{stroke:#6baed6}.epoch.category20c .category2 .area,.epoch.category20c .category2 .dot{fill:#6baed6;stroke:transparent}.epoch.category20c .arc.category2 path{fill:#6baed6}.epoch.category20c .bar.category2{fill:#6baed6}.epoch.category20c div.ref.category3{background-color:#9ecae1}.epoch.category20c .category3 .line{stroke:#9ecae1}.epoch.category20c .category3 .area,.epoch.category20c .category3 .dot{fill:#9ecae1;stroke:transparent}.epoch.category20c .arc.category3 path{fill:#9ecae1}.epoch.category20c .bar.category3{fill:#9ecae1}.epoch.category20c div.ref.category4{background-color:#c6dbef}.epoch.category20c .category4 .line{stroke:#c6dbef}.epoch.category20c .category4 .area,.epoch.category20c .category4 .dot{fill:#c6dbef;stroke:transparent}.epoch.category20c .arc.category4 path{fill:#c6dbef}.epoch.category20c .bar.category4{fill:#c6dbef}.epoch.category20c div.ref.category5{background-color:#e6550d}.epoch.category20c .category5 .line{stroke:#e6550d}.epoch.category20c .category5 .area,.epoch.category20c .category5 .dot{fill:#e6550d;stroke:transparent}.epoch.category20c .arc.category5 path{fill:#e6550d}.epoch.category20c .bar.category5{fill:#e6550d}.epoch.category20c div.ref.category6{background-color:#fd8d3c}.epoch.category20c .category6 .line{stroke:#fd8d3c}.epoch.category20c .category6 .area,.epoch.category20c .category6 .dot{fill:#fd8d3c;stroke:transparent}.epoch.category20c .arc.category6 path{fill:#fd8d3c}.epoch.category20c .bar.category6{fill:#fd8d3c}.epoch.category20c div.ref.category7{background-color:#fdae6b}.epoch.category20c .category7 .line{stroke:#fdae6b}.epoch.category20c .category7 .area,.epoch.category20c .category7 .dot{fill:#fdae6b;stroke:transparent}.epoch.category20c .arc.category7 path{fill:#fdae6b}.epoch.category20c .bar.category7{fill:#fdae6b}.epoch.category20c div.ref.category8{background-color:#fdd0a2}.epoch.category20c .category8 .line{stroke:#fdd0a2}.epoch.category20c .category8 .area,.epoch.category20c .category8 .dot{fill:#fdd0a2;stroke:transparent}.epoch.category20c .arc.category8 path{fill:#fdd0a2}.epoch.category20c .bar.category8{fill:#fdd0a2}.epoch.category20c div.ref.category9{background-color:#31a354}.epoch.category20c .category9 .line{stroke:#31a354}.epoch.category20c .category9 .area,.epoch.category20c .category9 .dot{fill:#31a354;stroke:transparent}.epoch.category20c .arc.category9 path{fill:#31a354}.epoch.category20c .bar.category9{fill:#31a354}.epoch.category20c div.ref.category10{background-color:#74c476}.epoch.category20c .category10 .line{stroke:#74c476}.epoch.category20c .category10 .area,.epoch.category20c .category10 .dot{fill:#74c476;stroke:transparent}.epoch.category20c .arc.category10 path{fill:#74c476}.epoch.category20c .bar.category10{fill:#74c476}.epoch.category20c div.ref.category11{background-color:#a1d99b}.epoch.category20c .category11 .line{stroke:#a1d99b}.epoch.category20c .category11 .area,.epoch.category20c .category11 .dot{fill:#a1d99b;stroke:transparent}.epoch.category20c .arc.category11 path{fill:#a1d99b}.epoch.category20c .bar.category11{fill:#a1d99b}.epoch.category20c div.ref.category12{background-color:#c7e9c0}.epoch.category20c .category12 .line{stroke:#c7e9c0}.epoch.category20c .category12 .area,.epoch.category20c .category12 .dot{fill:#c7e9c0;stroke:transparent}.epoch.category20c .arc.category12 path{fill:#c7e9c0}.epoch.category20c .bar.category12{fill:#c7e9c0}.epoch.category20c div.ref.category13{background-color:#756bb1}.epoch.category20c .category13 .line{stroke:#756bb1}.epoch.category20c .category13 .area,.epoch.category20c .category13 .dot{fill:#756bb1;stroke:transparent}.epoch.category20c .arc.category13 path{fill:#756bb1}.epoch.category20c .bar.category13{fill:#756bb1}.epoch.category20c div.ref.category14{background-color:#9e9ac8}.epoch.category20c .category14 .line{stroke:#9e9ac8}.epoch.category20c .category14 .area,.epoch.category20c .category14 .dot{fill:#9e9ac8;stroke:transparent}.epoch.category20c .arc.category14 path{fill:#9e9ac8}.epoch.category20c .bar.category14{fill:#9e9ac8}.epoch.category20c div.ref.category15{background-color:#bcbddc}.epoch.category20c .category15 .line{stroke:#bcbddc}.epoch.category20c .category15 .area,.epoch.category20c .category15 .dot{fill:#bcbddc;stroke:transparent}.epoch.category20c .arc.category15 path{fill:#bcbddc}.epoch.category20c .bar.category15{fill:#bcbddc}.epoch.category20c div.ref.category16{background-color:#dadaeb}.epoch.category20c .category16 .line{stroke:#dadaeb}.epoch.category20c .category16 .area,.epoch.category20c .category16 .dot{fill:#dadaeb;stroke:transparent}.epoch.category20c .arc.category16 path{fill:#dadaeb}.epoch.category20c .bar.category16{fill:#dadaeb}.epoch.category20c div.ref.category17{background-color:#636363}.epoch.category20c .category17 .line{stroke:#636363}.epoch.category20c .category17 .area,.epoch.category20c .category17 .dot{fill:#636363;stroke:transparent}.epoch.category20c .arc.category17 path{fill:#636363}.epoch.category20c .bar.category17{fill:#636363}.epoch.category20c div.ref.category18{background-color:#969696}.epoch.category20c .category18 .line{stroke:#969696}.epoch.category20c .category18 .area,.epoch.category20c .category18 .dot{fill:#969696;stroke:transparent}.epoch.category20c .arc.category18 path{fill:#969696}.epoch.category20c .bar.category18{fill:#969696}.epoch.category20c div.ref.category19{background-color:#bdbdbd}.epoch.category20c .category19 .line{stroke:#bdbdbd}.epoch.category20c .category19 .area,.epoch.category20c .category19 .dot{fill:#bdbdbd;stroke:transparent}.epoch.category20c .arc.category19 path{fill:#bdbdbd}.epoch.category20c .bar.category19{fill:#bdbdbd}.epoch.category20c div.ref.category20{background-color:#d9d9d9}.epoch.category20c .category20 .line{stroke:#d9d9d9}.epoch.category20c .category20 .area,.epoch.category20c .category20 .dot{fill:#d9d9d9;stroke:transparent}.epoch.category20c .arc.category20 path{fill:#d9d9d9}.epoch.category20c .bar.category20{fill:#d9d9d9}.epoch .category1 .bucket,.epoch.heatmap5 .category1 .bucket{fill:#1f77b4}.epoch .category2 .bucket,.epoch.heatmap5 .category2 .bucket{fill:#2ca02c}.epoch .category3 .bucket,.epoch.heatmap5 .category3 .bucket{fill:#d62728}.epoch .category4 .bucket,.epoch.heatmap5 .category4 .bucket{fill:#8c564b}.epoch .category5 .bucket,.epoch.heatmap5 .category5 .bucket{fill:#7f7f7f}.epoch-theme-dark .epoch .axis path,.epoch-theme-dark .epoch .axis line{stroke:#d0d0d0}.epoch-theme-dark .epoch .axis .tick text{fill:#d0d0d0}.epoch-theme-dark .arc.pie{stroke:#333}.epoch-theme-dark .arc.pie text{fill:#333}.epoch-theme-dark .epoch .gauge-labels .value{fill:#BBB}.epoch-theme-dark .epoch .gauge .arc.outer{stroke:#999}.epoch-theme-dark .epoch .gauge .arc.inner{stroke:#AAA}.epoch-theme-dark .epoch .gauge .tick{stroke:#AAA}.epoch-theme-dark .epoch .gauge .needle{fill:#F3DE88}.epoch-theme-dark .epoch .gauge .needle-base{fill:#999}.epoch-theme-dark .epoch div.ref.category1,.epoch-theme-dark .epoch.category10 div.ref.category1{background-color:#909CFF}.epoch-theme-dark .epoch .category1 .line,.epoch-theme-dark .epoch.category10 .category1 .line{stroke:#909CFF}.epoch-theme-dark .epoch .category1 .area,.epoch-theme-dark .epoch .category1 .dot,.epoch-theme-dark .epoch.category10 .category1 .area,.epoch-theme-dark .epoch.category10 .category1 .dot{fill:#909CFF;stroke:transparent}.epoch-theme-dark .epoch .arc.category1 path,.epoch-theme-dark .epoch.category10 .arc.category1 path{fill:#909CFF}.epoch-theme-dark .epoch .bar.category1,.epoch-theme-dark .epoch.category10 .bar.category1{fill:#909CFF}.epoch-theme-dark .epoch div.ref.category2,.epoch-theme-dark .epoch.category10 div.ref.category2{background-color:#FFAC89}.epoch-theme-dark .epoch .category2 .line,.epoch-theme-dark .epoch.category10 .category2 .line{stroke:#FFAC89}.epoch-theme-dark .epoch .category2 .area,.epoch-theme-dark .epoch .category2 .dot,.epoch-theme-dark .epoch.category10 .category2 .area,.epoch-theme-dark .epoch.category10 .category2 .dot{fill:#FFAC89;stroke:transparent}.epoch-theme-dark .epoch .arc.category2 path,.epoch-theme-dark .epoch.category10 .arc.category2 path{fill:#FFAC89}.epoch-theme-dark .epoch .bar.category2,.epoch-theme-dark .epoch.category10 .bar.category2{fill:#FFAC89}.epoch-theme-dark .epoch div.ref.category3,.epoch-theme-dark .epoch.category10 div.ref.category3{background-color:#E889E8}.epoch-theme-dark .epoch .category3 .line,.epoch-theme-dark .epoch.category10 .category3 .line{stroke:#E889E8}.epoch-theme-dark .epoch .category3 .area,.epoch-theme-dark .epoch .category3 .dot,.epoch-theme-dark .epoch.category10 .category3 .area,.epoch-theme-dark .epoch.category10 .category3 .dot{fill:#E889E8;stroke:transparent}.epoch-theme-dark .epoch .arc.category3 path,.epoch-theme-dark .epoch.category10 .arc.category3 path{fill:#E889E8}.epoch-theme-dark .epoch .bar.category3,.epoch-theme-dark .epoch.category10 .bar.category3{fill:#E889E8}.epoch-theme-dark .epoch div.ref.category4,.epoch-theme-dark .epoch.category10 div.ref.category4{background-color:#78E8D3}.epoch-theme-dark .epoch .category4 .line,.epoch-theme-dark .epoch.category10 .category4 .line{stroke:#78E8D3}.epoch-theme-dark .epoch .category4 .area,.epoch-theme-dark .epoch .category4 .dot,.epoch-theme-dark .epoch.category10 .category4 .area,.epoch-theme-dark .epoch.category10 .category4 .dot{fill:#78E8D3;stroke:transparent}.epoch-theme-dark .epoch .arc.category4 path,.epoch-theme-dark .epoch.category10 .arc.category4 path{fill:#78E8D3}.epoch-theme-dark .epoch .bar.category4,.epoch-theme-dark .epoch.category10 .bar.category4{fill:#78E8D3}.epoch-theme-dark .epoch div.ref.category5,.epoch-theme-dark .epoch.category10 div.ref.category5{background-color:#C2FF97}.epoch-theme-dark .epoch .category5 .line,.epoch-theme-dark .epoch.category10 .category5 .line{stroke:#C2FF97}.epoch-theme-dark .epoch .category5 .area,.epoch-theme-dark .epoch .category5 .dot,.epoch-theme-dark .epoch.category10 .category5 .area,.epoch-theme-dark .epoch.category10 .category5 .dot{fill:#C2FF97;stroke:transparent}.epoch-theme-dark .epoch .arc.category5 path,.epoch-theme-dark .epoch.category10 .arc.category5 path{fill:#C2FF97}.epoch-theme-dark .epoch .bar.category5,.epoch-theme-dark .epoch.category10 .bar.category5{fill:#C2FF97}.epoch-theme-dark .epoch div.ref.category6,.epoch-theme-dark .epoch.category10 div.ref.category6{background-color:#B7BCD1}.epoch-theme-dark .epoch .category6 .line,.epoch-theme-dark .epoch.category10 .category6 .line{stroke:#B7BCD1}.epoch-theme-dark .epoch .category6 .area,.epoch-theme-dark .epoch .category6 .dot,.epoch-theme-dark .epoch.category10 .category6 .area,.epoch-theme-dark .epoch.category10 .category6 .dot{fill:#B7BCD1;stroke:transparent}.epoch-theme-dark .epoch .arc.category6 path,.epoch-theme-dark .epoch.category10 .arc.category6 path{fill:#B7BCD1}.epoch-theme-dark .epoch .bar.category6,.epoch-theme-dark .epoch.category10 .bar.category6{fill:#B7BCD1}.epoch-theme-dark .epoch div.ref.category7,.epoch-theme-dark .epoch.category10 div.ref.category7{background-color:#FF857F}.epoch-theme-dark .epoch .category7 .line,.epoch-theme-dark .epoch.category10 .category7 .line{stroke:#FF857F}.epoch-theme-dark .epoch .category7 .area,.epoch-theme-dark .epoch .category7 .dot,.epoch-theme-dark .epoch.category10 .category7 .area,.epoch-theme-dark .epoch.category10 .category7 .dot{fill:#FF857F;stroke:transparent}.epoch-theme-dark .epoch .arc.category7 path,.epoch-theme-dark .epoch.category10 .arc.category7 path{fill:#FF857F}.epoch-theme-dark .epoch .bar.category7,.epoch-theme-dark .epoch.category10 .bar.category7{fill:#FF857F}.epoch-theme-dark .epoch div.ref.category8,.epoch-theme-dark .epoch.category10 div.ref.category8{background-color:#F3DE88}.epoch-theme-dark .epoch .category8 .line,.epoch-theme-dark .epoch.category10 .category8 .line{stroke:#F3DE88}.epoch-theme-dark .epoch .category8 .area,.epoch-theme-dark .epoch .category8 .dot,.epoch-theme-dark .epoch.category10 .category8 .area,.epoch-theme-dark .epoch.category10 .category8 .dot{fill:#F3DE88;stroke:transparent}.epoch-theme-dark .epoch .arc.category8 path,.epoch-theme-dark .epoch.category10 .arc.category8 path{fill:#F3DE88}.epoch-theme-dark .epoch .bar.category8,.epoch-theme-dark .epoch.category10 .bar.category8{fill:#F3DE88}.epoch-theme-dark .epoch div.ref.category9,.epoch-theme-dark .epoch.category10 div.ref.category9{background-color:#C9935E}.epoch-theme-dark .epoch .category9 .line,.epoch-theme-dark .epoch.category10 .category9 .line{stroke:#C9935E}.epoch-theme-dark .epoch .category9 .area,.epoch-theme-dark .epoch .category9 .dot,.epoch-theme-dark .epoch.category10 .category9 .area,.epoch-theme-dark .epoch.category10 .category9 .dot{fill:#C9935E;stroke:transparent}.epoch-theme-dark .epoch .arc.category9 path,.epoch-theme-dark .epoch.category10 .arc.category9 path{fill:#C9935E}.epoch-theme-dark .epoch .bar.category9,.epoch-theme-dark .epoch.category10 .bar.category9{fill:#C9935E}.epoch-theme-dark .epoch div.ref.category10,.epoch-theme-dark .epoch.category10 div.ref.category10{background-color:#A488FF}.epoch-theme-dark .epoch .category10 .line,.epoch-theme-dark .epoch.category10 .category10 .line{stroke:#A488FF}.epoch-theme-dark .epoch .category10 .area,.epoch-theme-dark .epoch .category10 .dot,.epoch-theme-dark .epoch.category10 .category10 .area,.epoch-theme-dark .epoch.category10 .category10 .dot{fill:#A488FF;stroke:transparent}.epoch-theme-dark .epoch .arc.category10 path,.epoch-theme-dark .epoch.category10 .arc.category10 path{fill:#A488FF}.epoch-theme-dark .epoch .bar.category10,.epoch-theme-dark .epoch.category10 .bar.category10{fill:#A488FF}.epoch-theme-dark .epoch.category20 div.ref.category1{background-color:#909CFF}.epoch-theme-dark .epoch.category20 .category1 .line{stroke:#909CFF}.epoch-theme-dark .epoch.category20 .category1 .area,.epoch-theme-dark .epoch.category20 .category1 .dot{fill:#909CFF;stroke:transparent}.epoch-theme-dark .epoch.category20 .arc.category1 path{fill:#909CFF}.epoch-theme-dark .epoch.category20 .bar.category1{fill:#909CFF}.epoch-theme-dark .epoch.category20 div.ref.category2{background-color:#626AAD}.epoch-theme-dark .epoch.category20 .category2 .line{stroke:#626AAD}.epoch-theme-dark .epoch.category20 .category2 .area,.epoch-theme-dark .epoch.category20 .category2 .dot{fill:#626AAD;stroke:transparent}.epoch-theme-dark .epoch.category20 .arc.category2 path{fill:#626AAD}.epoch-theme-dark .epoch.category20 .bar.category2{fill:#626AAD}.epoch-theme-dark .epoch.category20 div.ref.category3{background-color:#FFAC89}.epoch-theme-dark .epoch.category20 .category3 .line{stroke:#FFAC89}.epoch-theme-dark .epoch.category20 .category3 .area,.epoch-theme-dark .epoch.category20 .category3 .dot{fill:#FFAC89;stroke:transparent}.epoch-theme-dark .epoch.category20 .arc.category3 path{fill:#FFAC89}.epoch-theme-dark .epoch.category20 .bar.category3{fill:#FFAC89}.epoch-theme-dark .epoch.category20 div.ref.category4{background-color:#BD7F66}.epoch-theme-dark .epoch.category20 .category4 .line{stroke:#BD7F66}.epoch-theme-dark .epoch.category20 .category4 .area,.epoch-theme-dark .epoch.category20 .category4 .dot{fill:#BD7F66;stroke:transparent}.epoch-theme-dark .epoch.category20 .arc.category4 path{fill:#BD7F66}.epoch-theme-dark .epoch.category20 .bar.category4{fill:#BD7F66}.epoch-theme-dark .epoch.category20 div.ref.category5{background-color:#E889E8}.epoch-theme-dark .epoch.category20 .category5 .line{stroke:#E889E8}.epoch-theme-dark .epoch.category20 .category5 .area,.epoch-theme-dark .epoch.category20 .category5 .dot{fill:#E889E8;stroke:transparent}.epoch-theme-dark .epoch.category20 .arc.category5 path{fill:#E889E8}.epoch-theme-dark .epoch.category20 .bar.category5{fill:#E889E8}.epoch-theme-dark .epoch.category20 div.ref.category6{background-color:#995A99}.epoch-theme-dark .epoch.category20 .category6 .line{stroke:#995A99}.epoch-theme-dark .epoch.category20 .category6 .area,.epoch-theme-dark .epoch.category20 .category6 .dot{fill:#995A99;stroke:transparent}.epoch-theme-dark .epoch.category20 .arc.category6 path{fill:#995A99}.epoch-theme-dark .epoch.category20 .bar.category6{fill:#995A99}.epoch-theme-dark .epoch.category20 div.ref.category7{background-color:#78E8D3}.epoch-theme-dark .epoch.category20 .category7 .line{stroke:#78E8D3}.epoch-theme-dark .epoch.category20 .category7 .area,.epoch-theme-dark .epoch.category20 .category7 .dot{fill:#78E8D3;stroke:transparent}.epoch-theme-dark .epoch.category20 .arc.category7 path{fill:#78E8D3}.epoch-theme-dark .epoch.category20 .bar.category7{fill:#78E8D3}.epoch-theme-dark .epoch.category20 div.ref.category8{background-color:#4F998C}.epoch-theme-dark .epoch.category20 .category8 .line{stroke:#4F998C}.epoch-theme-dark .epoch.category20 .category8 .area,.epoch-theme-dark .epoch.category20 .category8 .dot{fill:#4F998C;stroke:transparent}.epoch-theme-dark .epoch.category20 .arc.category8 path{fill:#4F998C}.epoch-theme-dark .epoch.category20 .bar.category8{fill:#4F998C}.epoch-theme-dark .epoch.category20 div.ref.category9{background-color:#C2FF97}.epoch-theme-dark .epoch.category20 .category9 .line{stroke:#C2FF97}.epoch-theme-dark .epoch.category20 .category9 .area,.epoch-theme-dark .epoch.category20 .category9 .dot{fill:#C2FF97;stroke:transparent}.epoch-theme-dark .epoch.category20 .arc.category9 path{fill:#C2FF97}.epoch-theme-dark .epoch.category20 .bar.category9{fill:#C2FF97}.epoch-theme-dark .epoch.category20 div.ref.category10{background-color:#789E5E}.epoch-theme-dark .epoch.category20 .category10 .line{stroke:#789E5E}.epoch-theme-dark .epoch.category20 .category10 .area,.epoch-theme-dark .epoch.category20 .category10 .dot{fill:#789E5E;stroke:transparent}.epoch-theme-dark .epoch.category20 .arc.category10 path{fill:#789E5E}.epoch-theme-dark .epoch.category20 .bar.category10{fill:#789E5E}.epoch-theme-dark .epoch.category20 div.ref.category11{background-color:#B7BCD1}.epoch-theme-dark .epoch.category20 .category11 .line{stroke:#B7BCD1}.epoch-theme-dark .epoch.category20 .category11 .area,.epoch-theme-dark .epoch.category20 .category11 .dot{fill:#B7BCD1;stroke:transparent}.epoch-theme-dark .epoch.category20 .arc.category11 path{fill:#B7BCD1}.epoch-theme-dark .epoch.category20 .bar.category11{fill:#B7BCD1}.epoch-theme-dark .epoch.category20 div.ref.category12{background-color:#7F8391}.epoch-theme-dark .epoch.category20 .category12 .line{stroke:#7F8391}.epoch-theme-dark .epoch.category20 .category12 .area,.epoch-theme-dark .epoch.category20 .category12 .dot{fill:#7F8391;stroke:transparent}.epoch-theme-dark .epoch.category20 .arc.category12 path{fill:#7F8391}.epoch-theme-dark .epoch.category20 .bar.category12{fill:#7F8391}.epoch-theme-dark .epoch.category20 div.ref.category13{background-color:#CCB889}.epoch-theme-dark .epoch.category20 .category13 .line{stroke:#CCB889}.epoch-theme-dark .epoch.category20 .category13 .area,.epoch-theme-dark .epoch.category20 .category13 .dot{fill:#CCB889;stroke:transparent}.epoch-theme-dark .epoch.category20 .arc.category13 path{fill:#CCB889}.epoch-theme-dark .epoch.category20 .bar.category13{fill:#CCB889}.epoch-theme-dark .epoch.category20 div.ref.category14{background-color:#A1906B}.epoch-theme-dark .epoch.category20 .category14 .line{stroke:#A1906B}.epoch-theme-dark .epoch.category20 .category14 .area,.epoch-theme-dark .epoch.category20 .category14 .dot{fill:#A1906B;stroke:transparent}.epoch-theme-dark .epoch.category20 .arc.category14 path{fill:#A1906B}.epoch-theme-dark .epoch.category20 .bar.category14{fill:#A1906B}.epoch-theme-dark .epoch.category20 div.ref.category15{background-color:#F3DE88}.epoch-theme-dark .epoch.category20 .category15 .line{stroke:#F3DE88}.epoch-theme-dark .epoch.category20 .category15 .area,.epoch-theme-dark .epoch.category20 .category15 .dot{fill:#F3DE88;stroke:transparent}.epoch-theme-dark .epoch.category20 .arc.category15 path{fill:#F3DE88}.epoch-theme-dark .epoch.category20 .bar.category15{fill:#F3DE88}.epoch-theme-dark .epoch.category20 div.ref.category16{background-color:#A89A5E}.epoch-theme-dark .epoch.category20 .category16 .line{stroke:#A89A5E}.epoch-theme-dark .epoch.category20 .category16 .area,.epoch-theme-dark .epoch.category20 .category16 .dot{fill:#A89A5E;stroke:transparent}.epoch-theme-dark .epoch.category20 .arc.category16 path{fill:#A89A5E}.epoch-theme-dark .epoch.category20 .bar.category16{fill:#A89A5E}.epoch-theme-dark .epoch.category20 div.ref.category17{background-color:#FF857F}.epoch-theme-dark .epoch.category20 .category17 .line{stroke:#FF857F}.epoch-theme-dark .epoch.category20 .category17 .area,.epoch-theme-dark .epoch.category20 .category17 .dot{fill:#FF857F;stroke:transparent}.epoch-theme-dark .epoch.category20 .arc.category17 path{fill:#FF857F}.epoch-theme-dark .epoch.category20 .bar.category17{fill:#FF857F}.epoch-theme-dark .epoch.category20 div.ref.category18{background-color:#BA615D}.epoch-theme-dark .epoch.category20 .category18 .line{stroke:#BA615D}.epoch-theme-dark .epoch.category20 .category18 .area,.epoch-theme-dark .epoch.category20 .category18 .dot{fill:#BA615D;stroke:transparent}.epoch-theme-dark .epoch.category20 .arc.category18 path{fill:#BA615D}.epoch-theme-dark .epoch.category20 .bar.category18{fill:#BA615D}.epoch-theme-dark .epoch.category20 div.ref.category19{background-color:#A488FF}.epoch-theme-dark .epoch.category20 .category19 .line{stroke:#A488FF}.epoch-theme-dark .epoch.category20 .category19 .area,.epoch-theme-dark .epoch.category20 .category19 .dot{fill:#A488FF;stroke:transparent}.epoch-theme-dark .epoch.category20 .arc.category19 path{fill:#A488FF}.epoch-theme-dark .epoch.category20 .bar.category19{fill:#A488FF}.epoch-theme-dark .epoch.category20 div.ref.category20{background-color:#7662B8}.epoch-theme-dark .epoch.category20 .category20 .line{stroke:#7662B8}.epoch-theme-dark .epoch.category20 .category20 .area,.epoch-theme-dark .epoch.category20 .category20 .dot{fill:#7662B8;stroke:transparent}.epoch-theme-dark .epoch.category20 .arc.category20 path{fill:#7662B8}.epoch-theme-dark .epoch.category20 .bar.category20{fill:#7662B8}.epoch-theme-dark .epoch.category20b div.ref.category1{background-color:#909CFF}.epoch-theme-dark .epoch.category20b .category1 .line{stroke:#909CFF}.epoch-theme-dark .epoch.category20b .category1 .area,.epoch-theme-dark .epoch.category20b .category1 .dot{fill:#909CFF;stroke:transparent}.epoch-theme-dark .epoch.category20b .arc.category1 path{fill:#909CFF}.epoch-theme-dark .epoch.category20b .bar.category1{fill:#909CFF}.epoch-theme-dark .epoch.category20b div.ref.category2{background-color:#7680D1}.epoch-theme-dark .epoch.category20b .category2 .line{stroke:#7680D1}.epoch-theme-dark .epoch.category20b .category2 .area,.epoch-theme-dark .epoch.category20b .category2 .dot{fill:#7680D1;stroke:transparent}.epoch-theme-dark .epoch.category20b .arc.category2 path{fill:#7680D1}.epoch-theme-dark .epoch.category20b .bar.category2{fill:#7680D1}.epoch-theme-dark .epoch.category20b div.ref.category3{background-color:#656DB2}.epoch-theme-dark .epoch.category20b .category3 .line{stroke:#656DB2}.epoch-theme-dark .epoch.category20b .category3 .area,.epoch-theme-dark .epoch.category20b .category3 .dot{fill:#656DB2;stroke:transparent}.epoch-theme-dark .epoch.category20b .arc.category3 path{fill:#656DB2}.epoch-theme-dark .epoch.category20b .bar.category3{fill:#656DB2}.epoch-theme-dark .epoch.category20b div.ref.category4{background-color:#525992}.epoch-theme-dark .epoch.category20b .category4 .line{stroke:#525992}.epoch-theme-dark .epoch.category20b .category4 .area,.epoch-theme-dark .epoch.category20b .category4 .dot{fill:#525992;stroke:transparent}.epoch-theme-dark .epoch.category20b .arc.category4 path{fill:#525992}.epoch-theme-dark .epoch.category20b .bar.category4{fill:#525992}.epoch-theme-dark .epoch.category20b div.ref.category5{background-color:#FFAC89}.epoch-theme-dark .epoch.category20b .category5 .line{stroke:#FFAC89}.epoch-theme-dark .epoch.category20b .category5 .area,.epoch-theme-dark .epoch.category20b .category5 .dot{fill:#FFAC89;stroke:transparent}.epoch-theme-dark .epoch.category20b .arc.category5 path{fill:#FFAC89}.epoch-theme-dark .epoch.category20b .bar.category5{fill:#FFAC89}.epoch-theme-dark .epoch.category20b div.ref.category6{background-color:#D18D71}.epoch-theme-dark .epoch.category20b .category6 .line{stroke:#D18D71}.epoch-theme-dark .epoch.category20b .category6 .area,.epoch-theme-dark .epoch.category20b .category6 .dot{fill:#D18D71;stroke:transparent}.epoch-theme-dark .epoch.category20b .arc.category6 path{fill:#D18D71}.epoch-theme-dark .epoch.category20b .bar.category6{fill:#D18D71}.epoch-theme-dark .epoch.category20b div.ref.category7{background-color:#AB735C}.epoch-theme-dark .epoch.category20b .category7 .line{stroke:#AB735C}.epoch-theme-dark .epoch.category20b .category7 .area,.epoch-theme-dark .epoch.category20b .category7 .dot{fill:#AB735C;stroke:transparent}.epoch-theme-dark .epoch.category20b .arc.category7 path{fill:#AB735C}.epoch-theme-dark .epoch.category20b .bar.category7{fill:#AB735C}.epoch-theme-dark .epoch.category20b div.ref.category8{background-color:#92624E}.epoch-theme-dark .epoch.category20b .category8 .line{stroke:#92624E}.epoch-theme-dark .epoch.category20b .category8 .area,.epoch-theme-dark .epoch.category20b .category8 .dot{fill:#92624E;stroke:transparent}.epoch-theme-dark .epoch.category20b .arc.category8 path{fill:#92624E}.epoch-theme-dark .epoch.category20b .bar.category8{fill:#92624E}.epoch-theme-dark .epoch.category20b div.ref.category9{background-color:#E889E8}.epoch-theme-dark .epoch.category20b .category9 .line{stroke:#E889E8}.epoch-theme-dark .epoch.category20b .category9 .area,.epoch-theme-dark .epoch.category20b .category9 .dot{fill:#E889E8;stroke:transparent}.epoch-theme-dark .epoch.category20b .arc.category9 path{fill:#E889E8}.epoch-theme-dark .epoch.category20b .bar.category9{fill:#E889E8}.epoch-theme-dark .epoch.category20b div.ref.category10{background-color:#BA6EBA}.epoch-theme-dark .epoch.category20b .category10 .line{stroke:#BA6EBA}.epoch-theme-dark .epoch.category20b .category10 .area,.epoch-theme-dark .epoch.category20b .category10 .dot{fill:#BA6EBA;stroke:transparent}.epoch-theme-dark .epoch.category20b .arc.category10 path{fill:#BA6EBA}.epoch-theme-dark .epoch.category20b .bar.category10{fill:#BA6EBA}.epoch-theme-dark .epoch.category20b div.ref.category11{background-color:#9B5C9B}.epoch-theme-dark .epoch.category20b .category11 .line{stroke:#9B5C9B}.epoch-theme-dark .epoch.category20b .category11 .area,.epoch-theme-dark .epoch.category20b .category11 .dot{fill:#9B5C9B;stroke:transparent}.epoch-theme-dark .epoch.category20b .arc.category11 path{fill:#9B5C9B}.epoch-theme-dark .epoch.category20b .bar.category11{fill:#9B5C9B}.epoch-theme-dark .epoch.category20b div.ref.category12{background-color:#7B487B}.epoch-theme-dark .epoch.category20b .category12 .line{stroke:#7B487B}.epoch-theme-dark .epoch.category20b .category12 .area,.epoch-theme-dark .epoch.category20b .category12 .dot{fill:#7B487B;stroke:transparent}.epoch-theme-dark .epoch.category20b .arc.category12 path{fill:#7B487B}.epoch-theme-dark .epoch.category20b .bar.category12{fill:#7B487B}.epoch-theme-dark .epoch.category20b div.ref.category13{background-color:#78E8D3}.epoch-theme-dark .epoch.category20b .category13 .line{stroke:#78E8D3}.epoch-theme-dark .epoch.category20b .category13 .area,.epoch-theme-dark .epoch.category20b .category13 .dot{fill:#78E8D3;stroke:transparent}.epoch-theme-dark .epoch.category20b .arc.category13 path{fill:#78E8D3}.epoch-theme-dark .epoch.category20b .bar.category13{fill:#78E8D3}.epoch-theme-dark .epoch.category20b div.ref.category14{background-color:#60BAAA}.epoch-theme-dark .epoch.category20b .category14 .line{stroke:#60BAAA}.epoch-theme-dark .epoch.category20b .category14 .area,.epoch-theme-dark .epoch.category20b .category14 .dot{fill:#60BAAA;stroke:transparent}.epoch-theme-dark .epoch.category20b .arc.category14 path{fill:#60BAAA}.epoch-theme-dark .epoch.category20b .bar.category14{fill:#60BAAA}.epoch-theme-dark .epoch.category20b div.ref.category15{background-color:#509B8D}.epoch-theme-dark .epoch.category20b .category15 .line{stroke:#509B8D}.epoch-theme-dark .epoch.category20b .category15 .area,.epoch-theme-dark .epoch.category20b .category15 .dot{fill:#509B8D;stroke:transparent}.epoch-theme-dark .epoch.category20b .arc.category15 path{fill:#509B8D}.epoch-theme-dark .epoch.category20b .bar.category15{fill:#509B8D}.epoch-theme-dark .epoch.category20b div.ref.category16{background-color:#3F7B70}.epoch-theme-dark .epoch.category20b .category16 .line{stroke:#3F7B70}.epoch-theme-dark .epoch.category20b .category16 .area,.epoch-theme-dark .epoch.category20b .category16 .dot{fill:#3F7B70;stroke:transparent}.epoch-theme-dark .epoch.category20b .arc.category16 path{fill:#3F7B70}.epoch-theme-dark .epoch.category20b .bar.category16{fill:#3F7B70}.epoch-theme-dark .epoch.category20b div.ref.category17{background-color:#C2FF97}.epoch-theme-dark .epoch.category20b .category17 .line{stroke:#C2FF97}.epoch-theme-dark .epoch.category20b .category17 .area,.epoch-theme-dark .epoch.category20b .category17 .dot{fill:#C2FF97;stroke:transparent}.epoch-theme-dark .epoch.category20b .arc.category17 path{fill:#C2FF97}.epoch-theme-dark .epoch.category20b .bar.category17{fill:#C2FF97}.epoch-theme-dark .epoch.category20b div.ref.category18{background-color:#9FD17C}.epoch-theme-dark .epoch.category20b .category18 .line{stroke:#9FD17C}.epoch-theme-dark .epoch.category20b .category18 .area,.epoch-theme-dark .epoch.category20b .category18 .dot{fill:#9FD17C;stroke:transparent}.epoch-theme-dark .epoch.category20b .arc.category18 path{fill:#9FD17C}.epoch-theme-dark .epoch.category20b .bar.category18{fill:#9FD17C}.epoch-theme-dark .epoch.category20b div.ref.category19{background-color:#7DA361}.epoch-theme-dark .epoch.category20b .category19 .line{stroke:#7DA361}.epoch-theme-dark .epoch.category20b .category19 .area,.epoch-theme-dark .epoch.category20b .category19 .dot{fill:#7DA361;stroke:transparent}.epoch-theme-dark .epoch.category20b .arc.category19 path{fill:#7DA361}.epoch-theme-dark .epoch.category20b .bar.category19{fill:#7DA361}.epoch-theme-dark .epoch.category20b div.ref.category20{background-color:#65854E}.epoch-theme-dark .epoch.category20b .category20 .line{stroke:#65854E}.epoch-theme-dark .epoch.category20b .category20 .area,.epoch-theme-dark .epoch.category20b .category20 .dot{fill:#65854E;stroke:transparent}.epoch-theme-dark .epoch.category20b .arc.category20 path{fill:#65854E}.epoch-theme-dark .epoch.category20b .bar.category20{fill:#65854E}.epoch-theme-dark .epoch.category20c div.ref.category1{background-color:#B7BCD1}.epoch-theme-dark .epoch.category20c .category1 .line{stroke:#B7BCD1}.epoch-theme-dark .epoch.category20c .category1 .area,.epoch-theme-dark .epoch.category20c .category1 .dot{fill:#B7BCD1;stroke:transparent}.epoch-theme-dark .epoch.category20c .arc.category1 path{fill:#B7BCD1}.epoch-theme-dark .epoch.category20c .bar.category1{fill:#B7BCD1}.epoch-theme-dark .epoch.category20c div.ref.category2{background-color:#979DAD}.epoch-theme-dark .epoch.category20c .category2 .line{stroke:#979DAD}.epoch-theme-dark .epoch.category20c .category2 .area,.epoch-theme-dark .epoch.category20c .category2 .dot{fill:#979DAD;stroke:transparent}.epoch-theme-dark .epoch.category20c .arc.category2 path{fill:#979DAD}.epoch-theme-dark .epoch.category20c .bar.category2{fill:#979DAD}.epoch-theme-dark .epoch.category20c div.ref.category3{background-color:#6E717D}.epoch-theme-dark .epoch.category20c .category3 .line{stroke:#6E717D}.epoch-theme-dark .epoch.category20c .category3 .area,.epoch-theme-dark .epoch.category20c .category3 .dot{fill:#6E717D;stroke:transparent}.epoch-theme-dark .epoch.category20c .arc.category3 path{fill:#6E717D}.epoch-theme-dark .epoch.category20c .bar.category3{fill:#6E717D}.epoch-theme-dark .epoch.category20c div.ref.category4{background-color:#595C66}.epoch-theme-dark .epoch.category20c .category4 .line{stroke:#595C66}.epoch-theme-dark .epoch.category20c .category4 .area,.epoch-theme-dark .epoch.category20c .category4 .dot{fill:#595C66;stroke:transparent}.epoch-theme-dark .epoch.category20c .arc.category4 path{fill:#595C66}.epoch-theme-dark .epoch.category20c .bar.category4{fill:#595C66}.epoch-theme-dark .epoch.category20c div.ref.category5{background-color:#FF857F}.epoch-theme-dark .epoch.category20c .category5 .line{stroke:#FF857F}.epoch-theme-dark .epoch.category20c .category5 .area,.epoch-theme-dark .epoch.category20c .category5 .dot{fill:#FF857F;stroke:transparent}.epoch-theme-dark .epoch.category20c .arc.category5 path{fill:#FF857F}.epoch-theme-dark .epoch.category20c .bar.category5{fill:#FF857F}.epoch-theme-dark .epoch.category20c div.ref.category6{background-color:#DE746E}.epoch-theme-dark .epoch.category20c .category6 .line{stroke:#DE746E}.epoch-theme-dark .epoch.category20c .category6 .area,.epoch-theme-dark .epoch.category20c .category6 .dot{fill:#DE746E;stroke:transparent}.epoch-theme-dark .epoch.category20c .arc.category6 path{fill:#DE746E}.epoch-theme-dark .epoch.category20c .bar.category6{fill:#DE746E}.epoch-theme-dark .epoch.category20c div.ref.category7{background-color:#B55F5A}.epoch-theme-dark .epoch.category20c .category7 .line{stroke:#B55F5A}.epoch-theme-dark .epoch.category20c .category7 .area,.epoch-theme-dark .epoch.category20c .category7 .dot{fill:#B55F5A;stroke:transparent}.epoch-theme-dark .epoch.category20c .arc.category7 path{fill:#B55F5A}.epoch-theme-dark .epoch.category20c .bar.category7{fill:#B55F5A}.epoch-theme-dark .epoch.category20c div.ref.category8{background-color:#964E4B}.epoch-theme-dark .epoch.category20c .category8 .line{stroke:#964E4B}.epoch-theme-dark .epoch.category20c .category8 .area,.epoch-theme-dark .epoch.category20c .category8 .dot{fill:#964E4B;stroke:transparent}.epoch-theme-dark .epoch.category20c .arc.category8 path{fill:#964E4B}.epoch-theme-dark .epoch.category20c .bar.category8{fill:#964E4B}.epoch-theme-dark .epoch.category20c div.ref.category9{background-color:#F3DE88}.epoch-theme-dark .epoch.category20c .category9 .line{stroke:#F3DE88}.epoch-theme-dark .epoch.category20c .category9 .area,.epoch-theme-dark .epoch.category20c .category9 .dot{fill:#F3DE88;stroke:transparent}.epoch-theme-dark .epoch.category20c .arc.category9 path{fill:#F3DE88}.epoch-theme-dark .epoch.category20c .bar.category9{fill:#F3DE88}.epoch-theme-dark .epoch.category20c div.ref.category10{background-color:#DBC87B}.epoch-theme-dark .epoch.category20c .category10 .line{stroke:#DBC87B}.epoch-theme-dark .epoch.category20c .category10 .area,.epoch-theme-dark .epoch.category20c .category10 .dot{fill:#DBC87B;stroke:transparent}.epoch-theme-dark .epoch.category20c .arc.category10 path{fill:#DBC87B}.epoch-theme-dark .epoch.category20c .bar.category10{fill:#DBC87B}.epoch-theme-dark .epoch.category20c div.ref.category11{background-color:#BAAA68}.epoch-theme-dark .epoch.category20c .category11 .line{stroke:#BAAA68}.epoch-theme-dark .epoch.category20c .category11 .area,.epoch-theme-dark .epoch.category20c .category11 .dot{fill:#BAAA68;stroke:transparent}.epoch-theme-dark .epoch.category20c .arc.category11 path{fill:#BAAA68}.epoch-theme-dark .epoch.category20c .bar.category11{fill:#BAAA68}.epoch-theme-dark .epoch.category20c div.ref.category12{background-color:#918551}.epoch-theme-dark .epoch.category20c .category12 .line{stroke:#918551}.epoch-theme-dark .epoch.category20c .category12 .area,.epoch-theme-dark .epoch.category20c .category12 .dot{fill:#918551;stroke:transparent}.epoch-theme-dark .epoch.category20c .arc.category12 path{fill:#918551}.epoch-theme-dark .epoch.category20c .bar.category12{fill:#918551}.epoch-theme-dark .epoch.category20c div.ref.category13{background-color:#C9935E}.epoch-theme-dark .epoch.category20c .category13 .line{stroke:#C9935E}.epoch-theme-dark .epoch.category20c .category13 .area,.epoch-theme-dark .epoch.category20c .category13 .dot{fill:#C9935E;stroke:transparent}.epoch-theme-dark .epoch.category20c .arc.category13 path{fill:#C9935E}.epoch-theme-dark .epoch.category20c .bar.category13{fill:#C9935E}.epoch-theme-dark .epoch.category20c div.ref.category14{background-color:#B58455}.epoch-theme-dark .epoch.category20c .category14 .line{stroke:#B58455}.epoch-theme-dark .epoch.category20c .category14 .area,.epoch-theme-dark .epoch.category20c .category14 .dot{fill:#B58455;stroke:transparent}.epoch-theme-dark .epoch.category20c .arc.category14 path{fill:#B58455}.epoch-theme-dark .epoch.category20c .bar.category14{fill:#B58455}.epoch-theme-dark .epoch.category20c div.ref.category15{background-color:#997048}.epoch-theme-dark .epoch.category20c .category15 .line{stroke:#997048}.epoch-theme-dark .epoch.category20c .category15 .area,.epoch-theme-dark .epoch.category20c .category15 .dot{fill:#997048;stroke:transparent}.epoch-theme-dark .epoch.category20c .arc.category15 path{fill:#997048}.epoch-theme-dark .epoch.category20c .bar.category15{fill:#997048}.epoch-theme-dark .epoch.category20c div.ref.category16{background-color:#735436}.epoch-theme-dark .epoch.category20c .category16 .line{stroke:#735436}.epoch-theme-dark .epoch.category20c .category16 .area,.epoch-theme-dark .epoch.category20c .category16 .dot{fill:#735436;stroke:transparent}.epoch-theme-dark .epoch.category20c .arc.category16 path{fill:#735436}.epoch-theme-dark .epoch.category20c .bar.category16{fill:#735436}.epoch-theme-dark .epoch.category20c div.ref.category17{background-color:#A488FF}.epoch-theme-dark .epoch.category20c .category17 .line{stroke:#A488FF}.epoch-theme-dark .epoch.category20c .category17 .area,.epoch-theme-dark .epoch.category20c .category17 .dot{fill:#A488FF;stroke:transparent}.epoch-theme-dark .epoch.category20c .arc.category17 path{fill:#A488FF}.epoch-theme-dark .epoch.category20c .bar.category17{fill:#A488FF}.epoch-theme-dark .epoch.category20c div.ref.category18{background-color:#8670D1}.epoch-theme-dark .epoch.category20c .category18 .line{stroke:#8670D1}.epoch-theme-dark .epoch.category20c .category18 .area,.epoch-theme-dark .epoch.category20c .category18 .dot{fill:#8670D1;stroke:transparent}.epoch-theme-dark .epoch.category20c .arc.category18 path{fill:#8670D1}.epoch-theme-dark .epoch.category20c .bar.category18{fill:#8670D1}.epoch-theme-dark .epoch.category20c div.ref.category19{background-color:#705CAD}.epoch-theme-dark .epoch.category20c .category19 .line{stroke:#705CAD}.epoch-theme-dark .epoch.category20c .category19 .area,.epoch-theme-dark .epoch.category20c .category19 .dot{fill:#705CAD;stroke:transparent}.epoch-theme-dark .epoch.category20c .arc.category19 path{fill:#705CAD}.epoch-theme-dark .epoch.category20c .bar.category19{fill:#705CAD}.epoch-theme-dark .epoch.category20c div.ref.category20{background-color:#52447F}.epoch-theme-dark .epoch.category20c .category20 .line{stroke:#52447F}.epoch-theme-dark .epoch.category20c .category20 .area,.epoch-theme-dark .epoch.category20c .category20 .dot{fill:#52447F;stroke:transparent}.epoch-theme-dark .epoch.category20c .arc.category20 path{fill:#52447F}.epoch-theme-dark .epoch.category20c .bar.category20{fill:#52447F}
+.epoch .axis path,.epoch .axis line{shape-rendering:crispEdges}
+
+.epoch .axis.canvas .tick line{shape-rendering:geometricPrecision}
+
+div#_canvas_css_reference{width:0;height:0;position:absolute;top:-1000px;left:-1000px}
+
+div#_canvas_css_reference svg{position:absolute;width:0;height:0;top:-1000px;left:-1000px}
+
+.epoch{font-family:"Helvetica Neue", Helvetica, Arial, sans-serif;font-size:12pt}
+
+.epoch .axis path,.epoch .axis line{fill:transparent;stroke:#000}
+
+.epoch .axis .tick text{font-size:9pt}
+
+.epoch .line{fill:transparent;stroke-width:2px}
+
+.epoch.sparklines .line{stroke-width:1px}
+
+.epoch .area{stroke:transparent}
+
+.epoch .arc.pie{stroke:#fff;stroke-width:1.5px}
+
+.epoch .arc.pie text{stroke:transparent;fill:white;font-size:9pt}
+
+.epoch .gauge-labels .value{text-anchor:middle;font-size:140%;fill:#666}
+
+.epoch.gauge-tiny{width:120px;height:90px}
+
+.epoch.gauge-tiny .gauge-labels .value{font-size:80%}
+
+.epoch.gauge-tiny .gauge .arc.outer{stroke-width:2px}
+
+.epoch.gauge-small{width:180px;height:135px}
+
+.epoch.gauge-small .gauge-labels .value{font-size:120%}
+
+.epoch.gauge-small .gauge .arc.outer{stroke-width:3px}
+
+.epoch.gauge-medium{width:240px;height:180px}
+
+.epoch.gauge-medium .gauge .arc.outer{stroke-width:3px}
+
+.epoch.gauge-large{width:320px;height:240px}
+
+.epoch.gauge-large .gauge-labels .value{font-size:180%}
+
+.epoch .gauge .arc.outer{stroke-width:4px;stroke:#666}
+
+.epoch .gauge .arc.inner{stroke-width:1px;stroke:#555}
+
+.epoch .gauge .tick{stroke-width:1px;stroke:#555}
+
+.epoch .gauge .needle{fill:orange}
+
+.epoch .gauge .needle-base{fill:#666}
+
+.epoch div.ref.category1,.epoch.category10 div.ref.category1{background-color:#1f77b4}
+
+.epoch .category1 .line,.epoch.category10 .category1 .line{stroke:#1f77b4}
+
+.epoch .category1 .area,.epoch .category1 .dot,.epoch.category10 .category1 .area,.epoch.category10 .category1 .dot{fill:#1f77b4;stroke:transparent}
+
+.epoch .arc.category1 path,.epoch.category10 .arc.category1 path{fill:#1f77b4}
+
+.epoch .bar.category1,.epoch.category10 .bar.category1{fill:#1f77b4}
+
+.epoch div.ref.category2,.epoch.category10 div.ref.category2{background-color:#ff7f0e}
+
+.epoch .category2 .line,.epoch.category10 .category2 .line{stroke:#ff7f0e}
+
+.epoch .category2 .area,.epoch .category2 .dot,.epoch.category10 .category2 .area,.epoch.category10 .category2 .dot{fill:#ff7f0e;stroke:transparent}
+
+.epoch .arc.category2 path,.epoch.category10 .arc.category2 path{fill:#ff7f0e}
+
+.epoch .bar.category2,.epoch.category10 .bar.category2{fill:#ff7f0e}
+
+.epoch div.ref.category3,.epoch.category10 div.ref.category3{background-color:#2ca02c}
+
+.epoch .category3 .line,.epoch.category10 .category3 .line{stroke:#2ca02c}
+
+.epoch .category3 .area,.epoch .category3 .dot,.epoch.category10 .category3 .area,.epoch.category10 .category3 .dot{fill:#2ca02c;stroke:transparent}
+
+.epoch .arc.category3 path,.epoch.category10 .arc.category3 path{fill:#2ca02c}
+
+.epoch .bar.category3,.epoch.category10 .bar.category3{fill:#2ca02c}
+
+.epoch div.ref.category4,.epoch.category10 div.ref.category4{background-color:#d62728}
+
+.epoch .category4 .line,.epoch.category10 .category4 .line{stroke:#d62728}
+
+.epoch .category4 .area,.epoch .category4 .dot,.epoch.category10 .category4 .area,.epoch.category10 .category4 .dot{fill:#d62728;stroke:transparent}
+
+.epoch .arc.category4 path,.epoch.category10 .arc.category4 path{fill:#d62728}
+
+.epoch .bar.category4,.epoch.category10 .bar.category4{fill:#d62728}
+
+.epoch div.ref.category5,.epoch.category10 div.ref.category5{background-color:#9467bd}
+
+.epoch .category5 .line,.epoch.category10 .category5 .line{stroke:#9467bd}
+
+.epoch .category5 .area,.epoch .category5 .dot,.epoch.category10 .category5 .area,.epoch.category10 .category5 .dot{fill:#9467bd;stroke:transparent}
+
+.epoch .arc.category5 path,.epoch.category10 .arc.category5 path{fill:#9467bd}
+
+.epoch .bar.category5,.epoch.category10 .bar.category5{fill:#9467bd}
+
+.epoch div.ref.category6,.epoch.category10 div.ref.category6{background-color:#8c564b}
+
+.epoch .category6 .line,.epoch.category10 .category6 .line{stroke:#8c564b}
+
+.epoch .category6 .area,.epoch .category6 .dot,.epoch.category10 .category6 .area,.epoch.category10 .category6 .dot{fill:#8c564b;stroke:transparent}
+
+.epoch .arc.category6 path,.epoch.category10 .arc.category6 path{fill:#8c564b}
+
+.epoch .bar.category6,.epoch.category10 .bar.category6{fill:#8c564b}
+
+.epoch div.ref.category7,.epoch.category10 div.ref.category7{background-color:#e377c2}
+
+.epoch .category7 .line,.epoch.category10 .category7 .line{stroke:#e377c2}
+
+.epoch .category7 .area,.epoch .category7 .dot,.epoch.category10 .category7 .area,.epoch.category10 .category7 .dot{fill:#e377c2;stroke:transparent}
+
+.epoch .arc.category7 path,.epoch.category10 .arc.category7 path{fill:#e377c2}
+
+.epoch .bar.category7,.epoch.category10 .bar.category7{fill:#e377c2}
+
+.epoch div.ref.category8,.epoch.category10 div.ref.category8{background-color:#7f7f7f}
+
+.epoch .category8 .line,.epoch.category10 .category8 .line{stroke:#7f7f7f}
+
+.epoch .category8 .area,.epoch .category8 .dot,.epoch.category10 .category8 .area,.epoch.category10 .category8 .dot{fill:#7f7f7f;stroke:transparent}
+
+.epoch .arc.category8 path,.epoch.category10 .arc.category8 path{fill:#7f7f7f}
+
+.epoch .bar.category8,.epoch.category10 .bar.category8{fill:#7f7f7f}
+
+.epoch div.ref.category9,.epoch.category10 div.ref.category9{background-color:#bcbd22}
+
+.epoch .category9 .line,.epoch.category10 .category9 .line{stroke:#bcbd22}
+
+.epoch .category9 .area,.epoch .category9 .dot,.epoch.category10 .category9 .area,.epoch.category10 .category9 .dot{fill:#bcbd22;stroke:transparent}
+
+.epoch .arc.category9 path,.epoch.category10 .arc.category9 path{fill:#bcbd22}
+
+.epoch .bar.category9,.epoch.category10 .bar.category9{fill:#bcbd22}
+
+.epoch div.ref.category10,.epoch.category10 div.ref.category10{background-color:#17becf}
+
+.epoch .category10 .line,.epoch.category10 .category10 .line{stroke:#17becf}
+
+.epoch .category10 .area,.epoch .category10 .dot,.epoch.category10 .category10 .area,.epoch.category10 .category10 .dot{fill:#17becf;stroke:transparent}
+
+.epoch .arc.category10 path,.epoch.category10 .arc.category10 path{fill:#17becf}
+
+.epoch .bar.category10,.epoch.category10 .bar.category10{fill:#17becf}
+
+.epoch.category20 div.ref.category1{background-color:#1f77b4}
+
+.epoch.category20 .category1 .line{stroke:#1f77b4}
+
+.epoch.category20 .category1 .area,.epoch.category20 .category1 .dot{fill:#1f77b4;stroke:transparent}
+
+.epoch.category20 .arc.category1 path{fill:#1f77b4}
+
+.epoch.category20 .bar.category1{fill:#1f77b4}
+
+.epoch.category20 div.ref.category2{background-color:#aec7e8}
+
+.epoch.category20 .category2 .line{stroke:#aec7e8}
+
+.epoch.category20 .category2 .area,.epoch.category20 .category2 .dot{fill:#aec7e8;stroke:transparent}
+
+.epoch.category20 .arc.category2 path{fill:#aec7e8}
+
+.epoch.category20 .bar.category2{fill:#aec7e8}
+
+.epoch.category20 div.ref.category3{background-color:#ff7f0e}
+
+.epoch.category20 .category3 .line{stroke:#ff7f0e}
+
+.epoch.category20 .category3 .area,.epoch.category20 .category3 .dot{fill:#ff7f0e;stroke:transparent}
+
+.epoch.category20 .arc.category3 path{fill:#ff7f0e}
+
+.epoch.category20 .bar.category3{fill:#ff7f0e}
+
+.epoch.category20 div.ref.category4{background-color:#ffbb78}
+
+.epoch.category20 .category4 .line{stroke:#ffbb78}
+
+.epoch.category20 .category4 .area,.epoch.category20 .category4 .dot{fill:#ffbb78;stroke:transparent}
+
+.epoch.category20 .arc.category4 path{fill:#ffbb78}
+
+.epoch.category20 .bar.category4{fill:#ffbb78}
+
+.epoch.category20 div.ref.category5{background-color:#2ca02c}
+
+.epoch.category20 .category5 .line{stroke:#2ca02c}
+
+.epoch.category20 .category5 .area,.epoch.category20 .category5 .dot{fill:#2ca02c;stroke:transparent}
+
+.epoch.category20 .arc.category5 path{fill:#2ca02c}
+
+.epoch.category20 .bar.category5{fill:#2ca02c}
+
+.epoch.category20 div.ref.category6{background-color:#98df8a}
+
+.epoch.category20 .category6 .line{stroke:#98df8a}
+
+.epoch.category20 .category6 .area,.epoch.category20 .category6 .dot{fill:#98df8a;stroke:transparent}
+
+.epoch.category20 .arc.category6 path{fill:#98df8a}
+
+.epoch.category20 .bar.category6{fill:#98df8a}
+
+.epoch.category20 div.ref.category7{background-color:#d62728}
+
+.epoch.category20 .category7 .line{stroke:#d62728}
+
+.epoch.category20 .category7 .area,.epoch.category20 .category7 .dot{fill:#d62728;stroke:transparent}
+
+.epoch.category20 .arc.category7 path{fill:#d62728}
+
+.epoch.category20 .bar.category7{fill:#d62728}
+
+.epoch.category20 div.ref.category8{background-color:#ff9896}
+
+.epoch.category20 .category8 .line{stroke:#ff9896}
+
+.epoch.category20 .category8 .area,.epoch.category20 .category8 .dot{fill:#ff9896;stroke:transparent}
+
+.epoch.category20 .arc.category8 path{fill:#ff9896}
+
+.epoch.category20 .bar.category8{fill:#ff9896}
+
+.epoch.category20 div.ref.category9{background-color:#9467bd}
+
+.epoch.category20 .category9 .line{stroke:#9467bd}
+
+.epoch.category20 .category9 .area,.epoch.category20 .category9 .dot{fill:#9467bd;stroke:transparent}
+
+.epoch.category20 .arc.category9 path{fill:#9467bd}
+
+.epoch.category20 .bar.category9{fill:#9467bd}
+
+.epoch.category20 div.ref.category10{background-color:#c5b0d5}
+
+.epoch.category20 .category10 .line{stroke:#c5b0d5}
+
+.epoch.category20 .category10 .area,.epoch.category20 .category10 .dot{fill:#c5b0d5;stroke:transparent}
+
+.epoch.category20 .arc.category10 path{fill:#c5b0d5}
+
+.epoch.category20 .bar.category10{fill:#c5b0d5}
+
+.epoch.category20 div.ref.category11{background-color:#8c564b}
+
+.epoch.category20 .category11 .line{stroke:#8c564b}
+
+.epoch.category20 .category11 .area,.epoch.category20 .category11 .dot{fill:#8c564b;stroke:transparent}
+
+.epoch.category20 .arc.category11 path{fill:#8c564b}
+
+.epoch.category20 .bar.category11{fill:#8c564b}
+
+.epoch.category20 div.ref.category12{background-color:#c49c94}
+
+.epoch.category20 .category12 .line{stroke:#c49c94}
+
+.epoch.category20 .category12 .area,.epoch.category20 .category12 .dot{fill:#c49c94;stroke:transparent}
+
+.epoch.category20 .arc.category12 path{fill:#c49c94}
+
+.epoch.category20 .bar.category12{fill:#c49c94}
+
+.epoch.category20 div.ref.category13{background-color:#e377c2}
+
+.epoch.category20 .category13 .line{stroke:#e377c2}
+
+.epoch.category20 .category13 .area,.epoch.category20 .category13 .dot{fill:#e377c2;stroke:transparent}
+
+.epoch.category20 .arc.category13 path{fill:#e377c2}
+
+.epoch.category20 .bar.category13{fill:#e377c2}
+
+.epoch.category20 div.ref.category14{background-color:#f7b6d2}
+
+.epoch.category20 .category14 .line{stroke:#f7b6d2}
+
+.epoch.category20 .category14 .area,.epoch.category20 .category14 .dot{fill:#f7b6d2;stroke:transparent}
+
+.epoch.category20 .arc.category14 path{fill:#f7b6d2}
+
+.epoch.category20 .bar.category14{fill:#f7b6d2}
+
+.epoch.category20 div.ref.category15{background-color:#7f7f7f}
+
+.epoch.category20 .category15 .line{stroke:#7f7f7f}
+
+.epoch.category20 .category15 .area,.epoch.category20 .category15 .dot{fill:#7f7f7f;stroke:transparent}
+
+.epoch.category20 .arc.category15 path{fill:#7f7f7f}
+
+.epoch.category20 .bar.category15{fill:#7f7f7f}
+
+.epoch.category20 div.ref.category16{background-color:#c7c7c7}
+
+.epoch.category20 .category16 .line{stroke:#c7c7c7}
+
+.epoch.category20 .category16 .area,.epoch.category20 .category16 .dot{fill:#c7c7c7;stroke:transparent}
+
+.epoch.category20 .arc.category16 path{fill:#c7c7c7}
+
+.epoch.category20 .bar.category16{fill:#c7c7c7}
+
+.epoch.category20 div.ref.category17{background-color:#bcbd22}
+
+.epoch.category20 .category17 .line{stroke:#bcbd22}
+
+.epoch.category20 .category17 .area,.epoch.category20 .category17 .dot{fill:#bcbd22;stroke:transparent}
+
+.epoch.category20 .arc.category17 path{fill:#bcbd22}
+
+.epoch.category20 .bar.category17{fill:#bcbd22}
+
+.epoch.category20 div.ref.category18{background-color:#dbdb8d}
+
+.epoch.category20 .category18 .line{stroke:#dbdb8d}
+
+.epoch.category20 .category18 .area,.epoch.category20 .category18 .dot{fill:#dbdb8d;stroke:transparent}
+
+.epoch.category20 .arc.category18 path{fill:#dbdb8d}
+
+.epoch.category20 .bar.category18{fill:#dbdb8d}
+
+.epoch.category20 div.ref.category19{background-color:#17becf}
+
+.epoch.category20 .category19 .line{stroke:#17becf}
+
+.epoch.category20 .category19 .area,.epoch.category20 .category19 .dot{fill:#17becf;stroke:transparent}
+
+.epoch.category20 .arc.category19 path{fill:#17becf}
+
+.epoch.category20 .bar.category19{fill:#17becf}
+
+.epoch.category20 div.ref.category20{background-color:#9edae5}
+
+.epoch.category20 .category20 .line{stroke:#9edae5}
+
+.epoch.category20 .category20 .area,.epoch.category20 .category20 .dot{fill:#9edae5;stroke:transparent}
+
+.epoch.category20 .arc.category20 path{fill:#9edae5}
+
+.epoch.category20 .bar.category20{fill:#9edae5}
+
+.epoch.category20b div.ref.category1{background-color:#393b79}
+
+.epoch.category20b .category1 .line{stroke:#393b79}
+
+.epoch.category20b .category1 .area,.epoch.category20b .category1 .dot{fill:#393b79;stroke:transparent}
+
+.epoch.category20b .arc.category1 path{fill:#393b79}
+
+.epoch.category20b .bar.category1{fill:#393b79}
+
+.epoch.category20b div.ref.category2{background-color:#5254a3}
+
+.epoch.category20b .category2 .line{stroke:#5254a3}
+
+.epoch.category20b .category2 .area,.epoch.category20b .category2 .dot{fill:#5254a3;stroke:transparent}
+
+.epoch.category20b .arc.category2 path{fill:#5254a3}
+
+.epoch.category20b .bar.category2{fill:#5254a3}
+
+.epoch.category20b div.ref.category3{background-color:#6b6ecf}
+
+.epoch.category20b .category3 .line{stroke:#6b6ecf}
+
+.epoch.category20b .category3 .area,.epoch.category20b .category3 .dot{fill:#6b6ecf;stroke:transparent}
+
+.epoch.category20b .arc.category3 path{fill:#6b6ecf}
+
+.epoch.category20b .bar.category3{fill:#6b6ecf}
+
+.epoch.category20b div.ref.category4{background-color:#9c9ede}
+
+.epoch.category20b .category4 .line{stroke:#9c9ede}
+
+.epoch.category20b .category4 .area,.epoch.category20b .category4 .dot{fill:#9c9ede;stroke:transparent}
+
+.epoch.category20b .arc.category4 path{fill:#9c9ede}
+
+.epoch.category20b .bar.category4{fill:#9c9ede}
+
+.epoch.category20b div.ref.category5{background-color:#637939}
+
+.epoch.category20b .category5 .line{stroke:#637939}
+
+.epoch.category20b .category5 .area,.epoch.category20b .category5 .dot{fill:#637939;stroke:transparent}
+
+.epoch.category20b .arc.category5 path{fill:#637939}
+
+.epoch.category20b .bar.category5{fill:#637939}
+
+.epoch.category20b div.ref.category6{background-color:#8ca252}
+
+.epoch.category20b .category6 .line{stroke:#8ca252}
+
+.epoch.category20b .category6 .area,.epoch.category20b .category6 .dot{fill:#8ca252;stroke:transparent}
+
+.epoch.category20b .arc.category6 path{fill:#8ca252}
+
+.epoch.category20b .bar.category6{fill:#8ca252}
+
+.epoch.category20b div.ref.category7{background-color:#b5cf6b}
+
+.epoch.category20b .category7 .line{stroke:#b5cf6b}
+
+.epoch.category20b .category7 .area,.epoch.category20b .category7 .dot{fill:#b5cf6b;stroke:transparent}
+
+.epoch.category20b .arc.category7 path{fill:#b5cf6b}
+
+.epoch.category20b .bar.category7{fill:#b5cf6b}
+
+.epoch.category20b div.ref.category8{background-color:#cedb9c}
+
+.epoch.category20b .category8 .line{stroke:#cedb9c}
+
+.epoch.category20b .category8 .area,.epoch.category20b .category8 .dot{fill:#cedb9c;stroke:transparent}
+
+.epoch.category20b .arc.category8 path{fill:#cedb9c}
+
+.epoch.category20b .bar.category8{fill:#cedb9c}
+
+.epoch.category20b div.ref.category9{background-color:#8c6d31}
+
+.epoch.category20b .category9 .line{stroke:#8c6d31}
+
+.epoch.category20b .category9 .area,.epoch.category20b .category9 .dot{fill:#8c6d31;stroke:transparent}
+
+.epoch.category20b .arc.category9 path{fill:#8c6d31}
+
+.epoch.category20b .bar.category9{fill:#8c6d31}
+
+.epoch.category20b div.ref.category10{background-color:#bd9e39}
+
+.epoch.category20b .category10 .line{stroke:#bd9e39}
+
+.epoch.category20b .category10 .area,.epoch.category20b .category10 .dot{fill:#bd9e39;stroke:transparent}
+
+.epoch.category20b .arc.category10 path{fill:#bd9e39}
+
+.epoch.category20b .bar.category10{fill:#bd9e39}
+
+.epoch.category20b div.ref.category11{background-color:#e7ba52}
+
+.epoch.category20b .category11 .line{stroke:#e7ba52}
+
+.epoch.category20b .category11 .area,.epoch.category20b .category11 .dot{fill:#e7ba52;stroke:transparent}
+
+.epoch.category20b .arc.category11 path{fill:#e7ba52}
+
+.epoch.category20b .bar.category11{fill:#e7ba52}
+
+.epoch.category20b div.ref.category12{background-color:#e7cb94}
+
+.epoch.category20b .category12 .line{stroke:#e7cb94}
+
+.epoch.category20b .category12 .area,.epoch.category20b .category12 .dot{fill:#e7cb94;stroke:transparent}
+
+.epoch.category20b .arc.category12 path{fill:#e7cb94}
+
+.epoch.category20b .bar.category12{fill:#e7cb94}
+
+.epoch.category20b div.ref.category13{background-color:#843c39}
+
+.epoch.category20b .category13 .line{stroke:#843c39}
+
+.epoch.category20b .category13 .area,.epoch.category20b .category13 .dot{fill:#843c39;stroke:transparent}
+
+.epoch.category20b .arc.category13 path{fill:#843c39}
+
+.epoch.category20b .bar.category13{fill:#843c39}
+
+.epoch.category20b div.ref.category14{background-color:#ad494a}
+
+.epoch.category20b .category14 .line{stroke:#ad494a}
+
+.epoch.category20b .category14 .area,.epoch.category20b .category14 .dot{fill:#ad494a;stroke:transparent}
+
+.epoch.category20b .arc.category14 path{fill:#ad494a}
+
+.epoch.category20b .bar.category14{fill:#ad494a}
+
+.epoch.category20b div.ref.category15{background-color:#d6616b}
+
+.epoch.category20b .category15 .line{stroke:#d6616b}
+
+.epoch.category20b .category15 .area,.epoch.category20b .category15 .dot{fill:#d6616b;stroke:transparent}
+
+.epoch.category20b .arc.category15 path{fill:#d6616b}
+
+.epoch.category20b .bar.category15{fill:#d6616b}
+
+.epoch.category20b div.ref.category16{background-color:#e7969c}
+
+.epoch.category20b .category16 .line{stroke:#e7969c}
+
+.epoch.category20b .category16 .area,.epoch.category20b .category16 .dot{fill:#e7969c;stroke:transparent}
+
+.epoch.category20b .arc.category16 path{fill:#e7969c}
+
+.epoch.category20b .bar.category16{fill:#e7969c}
+
+.epoch.category20b div.ref.category17{background-color:#7b4173}
+
+.epoch.category20b .category17 .line{stroke:#7b4173}
+
+.epoch.category20b .category17 .area,.epoch.category20b .category17 .dot{fill:#7b4173;stroke:transparent}
+
+.epoch.category20b .arc.category17 path{fill:#7b4173}
+
+.epoch.category20b .bar.category17{fill:#7b4173}
+
+.epoch.category20b div.ref.category18{background-color:#a55194}
+
+.epoch.category20b .category18 .line{stroke:#a55194}
+
+.epoch.category20b .category18 .area,.epoch.category20b .category18 .dot{fill:#a55194;stroke:transparent}
+
+.epoch.category20b .arc.category18 path{fill:#a55194}
+
+.epoch.category20b .bar.category18{fill:#a55194}
+
+.epoch.category20b div.ref.category19{background-color:#ce6dbd}
+
+.epoch.category20b .category19 .line{stroke:#ce6dbd}
+
+.epoch.category20b .category19 .area,.epoch.category20b .category19 .dot{fill:#ce6dbd;stroke:transparent}
+
+.epoch.category20b .arc.category19 path{fill:#ce6dbd}
+
+.epoch.category20b .bar.category19{fill:#ce6dbd}
+
+.epoch.category20b div.ref.category20{background-color:#de9ed6}
+
+.epoch.category20b .category20 .line{stroke:#de9ed6}
+
+.epoch.category20b .category20 .area,.epoch.category20b .category20 .dot{fill:#de9ed6;stroke:transparent}
+
+.epoch.category20b .arc.category20 path{fill:#de9ed6}
+
+.epoch.category20b .bar.category20{fill:#de9ed6}
+
+.epoch.category20c div.ref.category1{background-color:#3182bd}
+
+.epoch.category20c .category1 .line{stroke:#3182bd}
+
+.epoch.category20c .category1 .area,.epoch.category20c .category1 .dot{fill:#3182bd;stroke:transparent}
+
+.epoch.category20c .arc.category1 path{fill:#3182bd}
+
+.epoch.category20c .bar.category1{fill:#3182bd}
+
+.epoch.category20c div.ref.category2{background-color:#6baed6}
+
+.epoch.category20c .category2 .line{stroke:#6baed6}
+
+.epoch.category20c .category2 .area,.epoch.category20c .category2 .dot{fill:#6baed6;stroke:transparent}
+
+.epoch.category20c .arc.category2 path{fill:#6baed6}
+
+.epoch.category20c .bar.category2{fill:#6baed6}
+
+.epoch.category20c div.ref.category3{background-color:#9ecae1}
+
+.epoch.category20c .category3 .line{stroke:#9ecae1}
+
+.epoch.category20c .category3 .area,.epoch.category20c .category3 .dot{fill:#9ecae1;stroke:transparent}
+
+.epoch.category20c .arc.category3 path{fill:#9ecae1}
+
+.epoch.category20c .bar.category3{fill:#9ecae1}
+
+.epoch.category20c div.ref.category4{background-color:#c6dbef}
+
+.epoch.category20c .category4 .line{stroke:#c6dbef}
+
+.epoch.category20c .category4 .area,.epoch.category20c .category4 .dot{fill:#c6dbef;stroke:transparent}
+
+.epoch.category20c .arc.category4 path{fill:#c6dbef}
+
+.epoch.category20c .bar.category4{fill:#c6dbef}
+
+.epoch.category20c div.ref.category5{background-color:#e6550d}
+
+.epoch.category20c .category5 .line{stroke:#e6550d}
+
+.epoch.category20c .category5 .area,.epoch.category20c .category5 .dot{fill:#e6550d;stroke:transparent}
+
+.epoch.category20c .arc.category5 path{fill:#e6550d}
+
+.epoch.category20c .bar.category5{fill:#e6550d}
+
+.epoch.category20c div.ref.category6{background-color:#fd8d3c}
+
+.epoch.category20c .category6 .line{stroke:#fd8d3c}
+
+.epoch.category20c .category6 .area,.epoch.category20c .category6 .dot{fill:#fd8d3c;stroke:transparent}
+
+.epoch.category20c .arc.category6 path{fill:#fd8d3c}
+
+.epoch.category20c .bar.category6{fill:#fd8d3c}
+
+.epoch.category20c div.ref.category7{background-color:#fdae6b}
+
+.epoch.category20c .category7 .line{stroke:#fdae6b}
+
+.epoch.category20c .category7 .area,.epoch.category20c .category7 .dot{fill:#fdae6b;stroke:transparent}
+
+.epoch.category20c .arc.category7 path{fill:#fdae6b}
+
+.epoch.category20c .bar.category7{fill:#fdae6b}
+
+.epoch.category20c div.ref.category8{background-color:#fdd0a2}
+
+.epoch.category20c .category8 .line{stroke:#fdd0a2}
+
+.epoch.category20c .category8 .area,.epoch.category20c .category8 .dot{fill:#fdd0a2;stroke:transparent}
+
+.epoch.category20c .arc.category8 path{fill:#fdd0a2}
+
+.epoch.category20c .bar.category8{fill:#fdd0a2}
+
+.epoch.category20c div.ref.category9{background-color:#31a354}
+
+.epoch.category20c .category9 .line{stroke:#31a354}
+
+.epoch.category20c .category9 .area,.epoch.category20c .category9 .dot{fill:#31a354;stroke:transparent}
+
+.epoch.category20c .arc.category9 path{fill:#31a354}
+
+.epoch.category20c .bar.category9{fill:#31a354}
+
+.epoch.category20c div.ref.category10{background-color:#74c476}
+
+.epoch.category20c .category10 .line{stroke:#74c476}
+
+.epoch.category20c .category10 .area,.epoch.category20c .category10 .dot{fill:#74c476;stroke:transparent}
+
+.epoch.category20c .arc.category10 path{fill:#74c476}
+
+.epoch.category20c .bar.category10{fill:#74c476}
+
+.epoch.category20c div.ref.category11{background-color:#a1d99b}
+
+.epoch.category20c .category11 .line{stroke:#a1d99b}
+
+.epoch.category20c .category11 .area,.epoch.category20c .category11 .dot{fill:#a1d99b;stroke:transparent}
+
+.epoch.category20c .arc.category11 path{fill:#a1d99b}
+
+.epoch.category20c .bar.category11{fill:#a1d99b}
+
+.epoch.category20c div.ref.category12{background-color:#c7e9c0}
+
+.epoch.category20c .category12 .line{stroke:#c7e9c0}
+
+.epoch.category20c .category12 .area,.epoch.category20c .category12 .dot{fill:#c7e9c0;stroke:transparent}
+
+.epoch.category20c .arc.category12 path{fill:#c7e9c0}
+
+.epoch.category20c .bar.category12{fill:#c7e9c0}
+
+.epoch.category20c div.ref.category13{background-color:#756bb1}
+
+.epoch.category20c .category13 .line{stroke:#756bb1}
+
+.epoch.category20c .category13 .area,.epoch.category20c .category13 .dot{fill:#756bb1;stroke:transparent}
+
+.epoch.category20c .arc.category13 path{fill:#756bb1}
+
+.epoch.category20c .bar.category13{fill:#756bb1}
+
+.epoch.category20c div.ref.category14{background-color:#9e9ac8}
+
+.epoch.category20c .category14 .line{stroke:#9e9ac8}
+
+.epoch.category20c .category14 .area,.epoch.category20c .category14 .dot{fill:#9e9ac8;stroke:transparent}
+
+.epoch.category20c .arc.category14 path{fill:#9e9ac8}
+
+.epoch.category20c .bar.category14{fill:#9e9ac8}
+
+.epoch.category20c div.ref.category15{background-color:#bcbddc}
+
+.epoch.category20c .category15 .line{stroke:#bcbddc}
+
+.epoch.category20c .category15 .area,.epoch.category20c .category15 .dot{fill:#bcbddc;stroke:transparent}
+
+.epoch.category20c .arc.category15 path{fill:#bcbddc}
+
+.epoch.category20c .bar.category15{fill:#bcbddc}
+
+.epoch.category20c div.ref.category16{background-color:#dadaeb}
+
+.epoch.category20c .category16 .line{stroke:#dadaeb}
+
+.epoch.category20c .category16 .area,.epoch.category20c .category16 .dot{fill:#dadaeb;stroke:transparent}
+
+.epoch.category20c .arc.category16 path{fill:#dadaeb}
+
+.epoch.category20c .bar.category16{fill:#dadaeb}
+
+.epoch.category20c div.ref.category17{background-color:#636363}
+
+.epoch.category20c .category17 .line{stroke:#636363}
+
+.epoch.category20c .category17 .area,.epoch.category20c .category17 .dot{fill:#636363;stroke:transparent}
+
+.epoch.category20c .arc.category17 path{fill:#636363}
+
+.epoch.category20c .bar.category17{fill:#636363}
+
+.epoch.category20c div.ref.category18{background-color:#969696}
+
+.epoch.category20c .category18 .line{stroke:#969696}
+
+.epoch.category20c .category18 .area,.epoch.category20c .category18 .dot{fill:#969696;stroke:transparent}
+
+.epoch.category20c .arc.category18 path{fill:#969696}
+
+.epoch.category20c .bar.category18{fill:#969696}
+
+.epoch.category20c div.ref.category19{background-color:#bdbdbd}
+
+.epoch.category20c .category19 .line{stroke:#bdbdbd}
+
+.epoch.category20c .category19 .area,.epoch.category20c .category19 .dot{fill:#bdbdbd;stroke:transparent}
+
+.epoch.category20c .arc.category19 path{fill:#bdbdbd}
+
+.epoch.category20c .bar.category19{fill:#bdbdbd}
+
+.epoch.category20c div.ref.category20{background-color:#d9d9d9}
+
+.epoch.category20c .category20 .line{stroke:#d9d9d9}
+
+.epoch.category20c .category20 .area,.epoch.category20c .category20 .dot{fill:#d9d9d9;stroke:transparent}
+
+.epoch.category20c .arc.category20 path{fill:#d9d9d9}
+
+.epoch.category20c .bar.category20{fill:#d9d9d9}
+
+.epoch .category1 .bucket,.epoch.heatmap5 .category1 .bucket{fill:#1f77b4}
+
+.epoch .category2 .bucket,.epoch.heatmap5 .category2 .bucket{fill:#2ca02c}
+
+.epoch .category3 .bucket,.epoch.heatmap5 .category3 .bucket{fill:#d62728}
+
+.epoch .category4 .bucket,.epoch.heatmap5 .category4 .bucket{fill:#8c564b}
+
+.epoch .category5 .bucket,.epoch.heatmap5 .category5 .bucket{fill:#7f7f7f}
+
+.epoch-theme-dark .epoch .axis path,.epoch-theme-dark .epoch .axis line{stroke:#d0d0d0}
+
+.epoch-theme-dark .epoch .axis .tick text{fill:#d0d0d0}
+
+.epoch-theme-dark .arc.pie{stroke:#333}
+
+.epoch-theme-dark .arc.pie text{fill:#333}
+
+.epoch-theme-dark .epoch .gauge-labels .value{fill:#BBB}
+
+.epoch-theme-dark .epoch .gauge .arc.outer{stroke:#999}
+
+.epoch-theme-dark .epoch .gauge .arc.inner{stroke:#AAA}
+
+.epoch-theme-dark .epoch .gauge .tick{stroke:#AAA}
+
+.epoch-theme-dark .epoch .gauge .needle{fill:#F3DE88}
+
+.epoch-theme-dark .epoch .gauge .needle-base{fill:#999}
+
+.epoch-theme-dark .epoch div.ref.category1,.epoch-theme-dark .epoch.category10 div.ref.category1{background-color:#909CFF}
+
+.epoch-theme-dark .epoch .category1 .line,.epoch-theme-dark .epoch.category10 .category1 .line{stroke:#909CFF}
+
+.epoch-theme-dark .epoch .category1 .area,.epoch-theme-dark .epoch .category1 .dot,.epoch-theme-dark .epoch.category10 .category1 .area,.epoch-theme-dark .epoch.category10 .category1 .dot{fill:#909CFF;stroke:transparent}
+
+.epoch-theme-dark .epoch .arc.category1 path,.epoch-theme-dark .epoch.category10 .arc.category1 path{fill:#909CFF}
+
+.epoch-theme-dark .epoch .bar.category1,.epoch-theme-dark .epoch.category10 .bar.category1{fill:#909CFF}
+
+.epoch-theme-dark .epoch div.ref.category2,.epoch-theme-dark .epoch.category10 div.ref.category2{background-color:#FFAC89}
+
+.epoch-theme-dark .epoch .category2 .line,.epoch-theme-dark .epoch.category10 .category2 .line{stroke:#FFAC89}
+
+.epoch-theme-dark .epoch .category2 .area,.epoch-theme-dark .epoch .category2 .dot,.epoch-theme-dark .epoch.category10 .category2 .area,.epoch-theme-dark .epoch.category10 .category2 .dot{fill:#FFAC89;stroke:transparent}
+
+.epoch-theme-dark .epoch .arc.category2 path,.epoch-theme-dark .epoch.category10 .arc.category2 path{fill:#FFAC89}
+
+.epoch-theme-dark .epoch .bar.category2,.epoch-theme-dark .epoch.category10 .bar.category2{fill:#FFAC89}
+
+.epoch-theme-dark .epoch div.ref.category3,.epoch-theme-dark .epoch.category10 div.ref.category3{background-color:#E889E8}
+
+.epoch-theme-dark .epoch .category3 .line,.epoch-theme-dark .epoch.category10 .category3 .line{stroke:#E889E8}
+
+.epoch-theme-dark .epoch .category3 .area,.epoch-theme-dark .epoch .category3 .dot,.epoch-theme-dark .epoch.category10 .category3 .area,.epoch-theme-dark .epoch.category10 .category3 .dot{fill:#E889E8;stroke:transparent}
+
+.epoch-theme-dark .epoch .arc.category3 path,.epoch-theme-dark .epoch.category10 .arc.category3 path{fill:#E889E8}
+
+.epoch-theme-dark .epoch .bar.category3,.epoch-theme-dark .epoch.category10 .bar.category3{fill:#E889E8}
+
+.epoch-theme-dark .epoch div.ref.category4,.epoch-theme-dark .epoch.category10 div.ref.category4{background-color:#78E8D3}
+
+.epoch-theme-dark .epoch .category4 .line,.epoch-theme-dark .epoch.category10 .category4 .line{stroke:#78E8D3}
+
+.epoch-theme-dark .epoch .category4 .area,.epoch-theme-dark .epoch .category4 .dot,.epoch-theme-dark .epoch.category10 .category4 .area,.epoch-theme-dark .epoch.category10 .category4 .dot{fill:#78E8D3;stroke:transparent}
+
+.epoch-theme-dark .epoch .arc.category4 path,.epoch-theme-dark .epoch.category10 .arc.category4 path{fill:#78E8D3}
+
+.epoch-theme-dark .epoch .bar.category4,.epoch-theme-dark .epoch.category10 .bar.category4{fill:#78E8D3}
+
+.epoch-theme-dark .epoch div.ref.category5,.epoch-theme-dark .epoch.category10 div.ref.category5{background-color:#C2FF97}
+
+.epoch-theme-dark .epoch .category5 .line,.epoch-theme-dark .epoch.category10 .category5 .line{stroke:#C2FF97}
+
+.epoch-theme-dark .epoch .category5 .area,.epoch-theme-dark .epoch .category5 .dot,.epoch-theme-dark .epoch.category10 .category5 .area,.epoch-theme-dark .epoch.category10 .category5 .dot{fill:#C2FF97;stroke:transparent}
+
+.epoch-theme-dark .epoch .arc.category5 path,.epoch-theme-dark .epoch.category10 .arc.category5 path{fill:#C2FF97}
+
+.epoch-theme-dark .epoch .bar.category5,.epoch-theme-dark .epoch.category10 .bar.category5{fill:#C2FF97}
+
+.epoch-theme-dark .epoch div.ref.category6,.epoch-theme-dark .epoch.category10 div.ref.category6{background-color:#B7BCD1}
+
+.epoch-theme-dark .epoch .category6 .line,.epoch-theme-dark .epoch.category10 .category6 .line{stroke:#B7BCD1}
+
+.epoch-theme-dark .epoch .category6 .area,.epoch-theme-dark .epoch .category6 .dot,.epoch-theme-dark .epoch.category10 .category6 .area,.epoch-theme-dark .epoch.category10 .category6 .dot{fill:#B7BCD1;stroke:transparent}
+
+.epoch-theme-dark .epoch .arc.category6 path,.epoch-theme-dark .epoch.category10 .arc.category6 path{fill:#B7BCD1}
+
+.epoch-theme-dark .epoch .bar.category6,.epoch-theme-dark .epoch.category10 .bar.category6{fill:#B7BCD1}
+
+.epoch-theme-dark .epoch div.ref.category7,.epoch-theme-dark .epoch.category10 div.ref.category7{background-color:#FF857F}
+
+.epoch-theme-dark .epoch .category7 .line,.epoch-theme-dark .epoch.category10 .category7 .line{stroke:#FF857F}
+
+.epoch-theme-dark .epoch .category7 .area,.epoch-theme-dark .epoch .category7 .dot,.epoch-theme-dark .epoch.category10 .category7 .area,.epoch-theme-dark .epoch.category10 .category7 .dot{fill:#FF857F;stroke:transparent}
+
+.epoch-theme-dark .epoch .arc.category7 path,.epoch-theme-dark .epoch.category10 .arc.category7 path{fill:#FF857F}
+
+.epoch-theme-dark .epoch .bar.category7,.epoch-theme-dark .epoch.category10 .bar.category7{fill:#FF857F}
+
+.epoch-theme-dark .epoch div.ref.category8,.epoch-theme-dark .epoch.category10 div.ref.category8{background-color:#F3DE88}
+
+.epoch-theme-dark .epoch .category8 .line,.epoch-theme-dark .epoch.category10 .category8 .line{stroke:#F3DE88}
+
+.epoch-theme-dark .epoch .category8 .area,.epoch-theme-dark .epoch .category8 .dot,.epoch-theme-dark .epoch.category10 .category8 .area,.epoch-theme-dark .epoch.category10 .category8 .dot{fill:#F3DE88;stroke:transparent}
+
+.epoch-theme-dark .epoch .arc.category8 path,.epoch-theme-dark .epoch.category10 .arc.category8 path{fill:#F3DE88}
+
+.epoch-theme-dark .epoch .bar.category8,.epoch-theme-dark .epoch.category10 .bar.category8{fill:#F3DE88}
+
+.epoch-theme-dark .epoch div.ref.category9,.epoch-theme-dark .epoch.category10 div.ref.category9{background-color:#C9935E}
+
+.epoch-theme-dark .epoch .category9 .line,.epoch-theme-dark .epoch.category10 .category9 .line{stroke:#C9935E}
+
+.epoch-theme-dark .epoch .category9 .area,.epoch-theme-dark .epoch .category9 .dot,.epoch-theme-dark .epoch.category10 .category9 .area,.epoch-theme-dark .epoch.category10 .category9 .dot{fill:#C9935E;stroke:transparent}
+
+.epoch-theme-dark .epoch .arc.category9 path,.epoch-theme-dark .epoch.category10 .arc.category9 path{fill:#C9935E}
+
+.epoch-theme-dark .epoch .bar.category9,.epoch-theme-dark .epoch.category10 .bar.category9{fill:#C9935E}
+
+.epoch-theme-dark .epoch div.ref.category10,.epoch-theme-dark .epoch.category10 div.ref.category10{background-color:#A488FF}
+
+.epoch-theme-dark .epoch .category10 .line,.epoch-theme-dark .epoch.category10 .category10 .line{stroke:#A488FF}
+
+.epoch-theme-dark .epoch .category10 .area,.epoch-theme-dark .epoch .category10 .dot,.epoch-theme-dark .epoch.category10 .category10 .area,.epoch-theme-dark .epoch.category10 .category10 .dot{fill:#A488FF;stroke:transparent}
+
+.epoch-theme-dark .epoch .arc.category10 path,.epoch-theme-dark .epoch.category10 .arc.category10 path{fill:#A488FF}
+
+.epoch-theme-dark .epoch .bar.category10,.epoch-theme-dark .epoch.category10 .bar.category10{fill:#A488FF}
+
+.epoch-theme-dark .epoch.category20 div.ref.category1{background-color:#909CFF}
+
+.epoch-theme-dark .epoch.category20 .category1 .line{stroke:#909CFF}
+
+.epoch-theme-dark .epoch.category20 .category1 .area,.epoch-theme-dark .epoch.category20 .category1 .dot{fill:#909CFF;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20 .arc.category1 path{fill:#909CFF}
+
+.epoch-theme-dark .epoch.category20 .bar.category1{fill:#909CFF}
+
+.epoch-theme-dark .epoch.category20 div.ref.category2{background-color:#626AAD}
+
+.epoch-theme-dark .epoch.category20 .category2 .line{stroke:#626AAD}
+
+.epoch-theme-dark .epoch.category20 .category2 .area,.epoch-theme-dark .epoch.category20 .category2 .dot{fill:#626AAD;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20 .arc.category2 path{fill:#626AAD}
+
+.epoch-theme-dark .epoch.category20 .bar.category2{fill:#626AAD}
+
+.epoch-theme-dark .epoch.category20 div.ref.category3{background-color:#FFAC89}
+
+.epoch-theme-dark .epoch.category20 .category3 .line{stroke:#FFAC89}
+
+.epoch-theme-dark .epoch.category20 .category3 .area,.epoch-theme-dark .epoch.category20 .category3 .dot{fill:#FFAC89;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20 .arc.category3 path{fill:#FFAC89}
+
+.epoch-theme-dark .epoch.category20 .bar.category3{fill:#FFAC89}
+
+.epoch-theme-dark .epoch.category20 div.ref.category4{background-color:#BD7F66}
+
+.epoch-theme-dark .epoch.category20 .category4 .line{stroke:#BD7F66}
+
+.epoch-theme-dark .epoch.category20 .category4 .area,.epoch-theme-dark .epoch.category20 .category4 .dot{fill:#BD7F66;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20 .arc.category4 path{fill:#BD7F66}
+
+.epoch-theme-dark .epoch.category20 .bar.category4{fill:#BD7F66}
+
+.epoch-theme-dark .epoch.category20 div.ref.category5{background-color:#E889E8}
+
+.epoch-theme-dark .epoch.category20 .category5 .line{stroke:#E889E8}
+
+.epoch-theme-dark .epoch.category20 .category5 .area,.epoch-theme-dark .epoch.category20 .category5 .dot{fill:#E889E8;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20 .arc.category5 path{fill:#E889E8}
+
+.epoch-theme-dark .epoch.category20 .bar.category5{fill:#E889E8}
+
+.epoch-theme-dark .epoch.category20 div.ref.category6{background-color:#995A99}
+
+.epoch-theme-dark .epoch.category20 .category6 .line{stroke:#995A99}
+
+.epoch-theme-dark .epoch.category20 .category6 .area,.epoch-theme-dark .epoch.category20 .category6 .dot{fill:#995A99;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20 .arc.category6 path{fill:#995A99}
+
+.epoch-theme-dark .epoch.category20 .bar.category6{fill:#995A99}
+
+.epoch-theme-dark .epoch.category20 div.ref.category7{background-color:#78E8D3}
+
+.epoch-theme-dark .epoch.category20 .category7 .line{stroke:#78E8D3}
+
+.epoch-theme-dark .epoch.category20 .category7 .area,.epoch-theme-dark .epoch.category20 .category7 .dot{fill:#78E8D3;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20 .arc.category7 path{fill:#78E8D3}
+
+.epoch-theme-dark .epoch.category20 .bar.category7{fill:#78E8D3}
+
+.epoch-theme-dark .epoch.category20 div.ref.category8{background-color:#4F998C}
+
+.epoch-theme-dark .epoch.category20 .category8 .line{stroke:#4F998C}
+
+.epoch-theme-dark .epoch.category20 .category8 .area,.epoch-theme-dark .epoch.category20 .category8 .dot{fill:#4F998C;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20 .arc.category8 path{fill:#4F998C}
+
+.epoch-theme-dark .epoch.category20 .bar.category8{fill:#4F998C}
+
+.epoch-theme-dark .epoch.category20 div.ref.category9{background-color:#C2FF97}
+
+.epoch-theme-dark .epoch.category20 .category9 .line{stroke:#C2FF97}
+
+.epoch-theme-dark .epoch.category20 .category9 .area,.epoch-theme-dark .epoch.category20 .category9 .dot{fill:#C2FF97;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20 .arc.category9 path{fill:#C2FF97}
+
+.epoch-theme-dark .epoch.category20 .bar.category9{fill:#C2FF97}
+
+.epoch-theme-dark .epoch.category20 div.ref.category10{background-color:#789E5E}
+
+.epoch-theme-dark .epoch.category20 .category10 .line{stroke:#789E5E}
+
+.epoch-theme-dark .epoch.category20 .category10 .area,.epoch-theme-dark .epoch.category20 .category10 .dot{fill:#789E5E;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20 .arc.category10 path{fill:#789E5E}
+
+.epoch-theme-dark .epoch.category20 .bar.category10{fill:#789E5E}
+
+.epoch-theme-dark .epoch.category20 div.ref.category11{background-color:#B7BCD1}
+
+.epoch-theme-dark .epoch.category20 .category11 .line{stroke:#B7BCD1}
+
+.epoch-theme-dark .epoch.category20 .category11 .area,.epoch-theme-dark .epoch.category20 .category11 .dot{fill:#B7BCD1;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20 .arc.category11 path{fill:#B7BCD1}
+
+.epoch-theme-dark .epoch.category20 .bar.category11{fill:#B7BCD1}
+
+.epoch-theme-dark .epoch.category20 div.ref.category12{background-color:#7F8391}
+
+.epoch-theme-dark .epoch.category20 .category12 .line{stroke:#7F8391}
+
+.epoch-theme-dark .epoch.category20 .category12 .area,.epoch-theme-dark .epoch.category20 .category12 .dot{fill:#7F8391;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20 .arc.category12 path{fill:#7F8391}
+
+.epoch-theme-dark .epoch.category20 .bar.category12{fill:#7F8391}
+
+.epoch-theme-dark .epoch.category20 div.ref.category13{background-color:#CCB889}
+
+.epoch-theme-dark .epoch.category20 .category13 .line{stroke:#CCB889}
+
+.epoch-theme-dark .epoch.category20 .category13 .area,.epoch-theme-dark .epoch.category20 .category13 .dot{fill:#CCB889;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20 .arc.category13 path{fill:#CCB889}
+
+.epoch-theme-dark .epoch.category20 .bar.category13{fill:#CCB889}
+
+.epoch-theme-dark .epoch.category20 div.ref.category14{background-color:#A1906B}
+
+.epoch-theme-dark .epoch.category20 .category14 .line{stroke:#A1906B}
+
+.epoch-theme-dark .epoch.category20 .category14 .area,.epoch-theme-dark .epoch.category20 .category14 .dot{fill:#A1906B;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20 .arc.category14 path{fill:#A1906B}
+
+.epoch-theme-dark .epoch.category20 .bar.category14{fill:#A1906B}
+
+.epoch-theme-dark .epoch.category20 div.ref.category15{background-color:#F3DE88}
+
+.epoch-theme-dark .epoch.category20 .category15 .line{stroke:#F3DE88}
+
+.epoch-theme-dark .epoch.category20 .category15 .area,.epoch-theme-dark .epoch.category20 .category15 .dot{fill:#F3DE88;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20 .arc.category15 path{fill:#F3DE88}
+
+.epoch-theme-dark .epoch.category20 .bar.category15{fill:#F3DE88}
+
+.epoch-theme-dark .epoch.category20 div.ref.category16{background-color:#A89A5E}
+
+.epoch-theme-dark .epoch.category20 .category16 .line{stroke:#A89A5E}
+
+.epoch-theme-dark .epoch.category20 .category16 .area,.epoch-theme-dark .epoch.category20 .category16 .dot{fill:#A89A5E;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20 .arc.category16 path{fill:#A89A5E}
+
+.epoch-theme-dark .epoch.category20 .bar.category16{fill:#A89A5E}
+
+.epoch-theme-dark .epoch.category20 div.ref.category17{background-color:#FF857F}
+
+.epoch-theme-dark .epoch.category20 .category17 .line{stroke:#FF857F}
+
+.epoch-theme-dark .epoch.category20 .category17 .area,.epoch-theme-dark .epoch.category20 .category17 .dot{fill:#FF857F;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20 .arc.category17 path{fill:#FF857F}
+
+.epoch-theme-dark .epoch.category20 .bar.category17{fill:#FF857F}
+
+.epoch-theme-dark .epoch.category20 div.ref.category18{background-color:#BA615D}
+
+.epoch-theme-dark .epoch.category20 .category18 .line{stroke:#BA615D}
+
+.epoch-theme-dark .epoch.category20 .category18 .area,.epoch-theme-dark .epoch.category20 .category18 .dot{fill:#BA615D;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20 .arc.category18 path{fill:#BA615D}
+
+.epoch-theme-dark .epoch.category20 .bar.category18{fill:#BA615D}
+
+.epoch-theme-dark .epoch.category20 div.ref.category19{background-color:#A488FF}
+
+.epoch-theme-dark .epoch.category20 .category19 .line{stroke:#A488FF}
+
+.epoch-theme-dark .epoch.category20 .category19 .area,.epoch-theme-dark .epoch.category20 .category19 .dot{fill:#A488FF;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20 .arc.category19 path{fill:#A488FF}
+
+.epoch-theme-dark .epoch.category20 .bar.category19{fill:#A488FF}
+
+.epoch-theme-dark .epoch.category20 div.ref.category20{background-color:#7662B8}
+
+.epoch-theme-dark .epoch.category20 .category20 .line{stroke:#7662B8}
+
+.epoch-theme-dark .epoch.category20 .category20 .area,.epoch-theme-dark .epoch.category20 .category20 .dot{fill:#7662B8;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20 .arc.category20 path{fill:#7662B8}
+
+.epoch-theme-dark .epoch.category20 .bar.category20{fill:#7662B8}
+
+.epoch-theme-dark .epoch.category20b div.ref.category1{background-color:#909CFF}
+
+.epoch-theme-dark .epoch.category20b .category1 .line{stroke:#909CFF}
+
+.epoch-theme-dark .epoch.category20b .category1 .area,.epoch-theme-dark .epoch.category20b .category1 .dot{fill:#909CFF;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20b .arc.category1 path{fill:#909CFF}
+
+.epoch-theme-dark .epoch.category20b .bar.category1{fill:#909CFF}
+
+.epoch-theme-dark .epoch.category20b div.ref.category2{background-color:#7680D1}
+
+.epoch-theme-dark .epoch.category20b .category2 .line{stroke:#7680D1}
+
+.epoch-theme-dark .epoch.category20b .category2 .area,.epoch-theme-dark .epoch.category20b .category2 .dot{fill:#7680D1;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20b .arc.category2 path{fill:#7680D1}
+
+.epoch-theme-dark .epoch.category20b .bar.category2{fill:#7680D1}
+
+.epoch-theme-dark .epoch.category20b div.ref.category3{background-color:#656DB2}
+
+.epoch-theme-dark .epoch.category20b .category3 .line{stroke:#656DB2}
+
+.epoch-theme-dark .epoch.category20b .category3 .area,.epoch-theme-dark .epoch.category20b .category3 .dot{fill:#656DB2;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20b .arc.category3 path{fill:#656DB2}
+
+.epoch-theme-dark .epoch.category20b .bar.category3{fill:#656DB2}
+
+.epoch-theme-dark .epoch.category20b div.ref.category4{background-color:#525992}
+
+.epoch-theme-dark .epoch.category20b .category4 .line{stroke:#525992}
+
+.epoch-theme-dark .epoch.category20b .category4 .area,.epoch-theme-dark .epoch.category20b .category4 .dot{fill:#525992;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20b .arc.category4 path{fill:#525992}
+
+.epoch-theme-dark .epoch.category20b .bar.category4{fill:#525992}
+
+.epoch-theme-dark .epoch.category20b div.ref.category5{background-color:#FFAC89}
+
+.epoch-theme-dark .epoch.category20b .category5 .line{stroke:#FFAC89}
+
+.epoch-theme-dark .epoch.category20b .category5 .area,.epoch-theme-dark .epoch.category20b .category5 .dot{fill:#FFAC89;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20b .arc.category5 path{fill:#FFAC89}
+
+.epoch-theme-dark .epoch.category20b .bar.category5{fill:#FFAC89}
+
+.epoch-theme-dark .epoch.category20b div.ref.category6{background-color:#D18D71}
+
+.epoch-theme-dark .epoch.category20b .category6 .line{stroke:#D18D71}
+
+.epoch-theme-dark .epoch.category20b .category6 .area,.epoch-theme-dark .epoch.category20b .category6 .dot{fill:#D18D71;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20b .arc.category6 path{fill:#D18D71}
+
+.epoch-theme-dark .epoch.category20b .bar.category6{fill:#D18D71}
+
+.epoch-theme-dark .epoch.category20b div.ref.category7{background-color:#AB735C}
+
+.epoch-theme-dark .epoch.category20b .category7 .line{stroke:#AB735C}
+
+.epoch-theme-dark .epoch.category20b .category7 .area,.epoch-theme-dark .epoch.category20b .category7 .dot{fill:#AB735C;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20b .arc.category7 path{fill:#AB735C}
+
+.epoch-theme-dark .epoch.category20b .bar.category7{fill:#AB735C}
+
+.epoch-theme-dark .epoch.category20b div.ref.category8{background-color:#92624E}
+
+.epoch-theme-dark .epoch.category20b .category8 .line{stroke:#92624E}
+
+.epoch-theme-dark .epoch.category20b .category8 .area,.epoch-theme-dark .epoch.category20b .category8 .dot{fill:#92624E;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20b .arc.category8 path{fill:#92624E}
+
+.epoch-theme-dark .epoch.category20b .bar.category8{fill:#92624E}
+
+.epoch-theme-dark .epoch.category20b div.ref.category9{background-color:#E889E8}
+
+.epoch-theme-dark .epoch.category20b .category9 .line{stroke:#E889E8}
+
+.epoch-theme-dark .epoch.category20b .category9 .area,.epoch-theme-dark .epoch.category20b .category9 .dot{fill:#E889E8;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20b .arc.category9 path{fill:#E889E8}
+
+.epoch-theme-dark .epoch.category20b .bar.category9{fill:#E889E8}
+
+.epoch-theme-dark .epoch.category20b div.ref.category10{background-color:#BA6EBA}
+
+.epoch-theme-dark .epoch.category20b .category10 .line{stroke:#BA6EBA}
+
+.epoch-theme-dark .epoch.category20b .category10 .area,.epoch-theme-dark .epoch.category20b .category10 .dot{fill:#BA6EBA;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20b .arc.category10 path{fill:#BA6EBA}
+
+.epoch-theme-dark .epoch.category20b .bar.category10{fill:#BA6EBA}
+
+.epoch-theme-dark .epoch.category20b div.ref.category11{background-color:#9B5C9B}
+
+.epoch-theme-dark .epoch.category20b .category11 .line{stroke:#9B5C9B}
+
+.epoch-theme-dark .epoch.category20b .category11 .area,.epoch-theme-dark .epoch.category20b .category11 .dot{fill:#9B5C9B;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20b .arc.category11 path{fill:#9B5C9B}
+
+.epoch-theme-dark .epoch.category20b .bar.category11{fill:#9B5C9B}
+
+.epoch-theme-dark .epoch.category20b div.ref.category12{background-color:#7B487B}
+
+.epoch-theme-dark .epoch.category20b .category12 .line{stroke:#7B487B}
+
+.epoch-theme-dark .epoch.category20b .category12 .area,.epoch-theme-dark .epoch.category20b .category12 .dot{fill:#7B487B;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20b .arc.category12 path{fill:#7B487B}
+
+.epoch-theme-dark .epoch.category20b .bar.category12{fill:#7B487B}
+
+.epoch-theme-dark .epoch.category20b div.ref.category13{background-color:#78E8D3}
+
+.epoch-theme-dark .epoch.category20b .category13 .line{stroke:#78E8D3}
+
+.epoch-theme-dark .epoch.category20b .category13 .area,.epoch-theme-dark .epoch.category20b .category13 .dot{fill:#78E8D3;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20b .arc.category13 path{fill:#78E8D3}
+
+.epoch-theme-dark .epoch.category20b .bar.category13{fill:#78E8D3}
+
+.epoch-theme-dark .epoch.category20b div.ref.category14{background-color:#60BAAA}
+
+.epoch-theme-dark .epoch.category20b .category14 .line{stroke:#60BAAA}
+
+.epoch-theme-dark .epoch.category20b .category14 .area,.epoch-theme-dark .epoch.category20b .category14 .dot{fill:#60BAAA;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20b .arc.category14 path{fill:#60BAAA}
+
+.epoch-theme-dark .epoch.category20b .bar.category14{fill:#60BAAA}
+
+.epoch-theme-dark .epoch.category20b div.ref.category15{background-color:#509B8D}
+
+.epoch-theme-dark .epoch.category20b .category15 .line{stroke:#509B8D}
+
+.epoch-theme-dark .epoch.category20b .category15 .area,.epoch-theme-dark .epoch.category20b .category15 .dot{fill:#509B8D;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20b .arc.category15 path{fill:#509B8D}
+
+.epoch-theme-dark .epoch.category20b .bar.category15{fill:#509B8D}
+
+.epoch-theme-dark .epoch.category20b div.ref.category16{background-color:#3F7B70}
+
+.epoch-theme-dark .epoch.category20b .category16 .line{stroke:#3F7B70}
+
+.epoch-theme-dark .epoch.category20b .category16 .area,.epoch-theme-dark .epoch.category20b .category16 .dot{fill:#3F7B70;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20b .arc.category16 path{fill:#3F7B70}
+
+.epoch-theme-dark .epoch.category20b .bar.category16{fill:#3F7B70}
+
+.epoch-theme-dark .epoch.category20b div.ref.category17{background-color:#C2FF97}
+
+.epoch-theme-dark .epoch.category20b .category17 .line{stroke:#C2FF97}
+
+.epoch-theme-dark .epoch.category20b .category17 .area,.epoch-theme-dark .epoch.category20b .category17 .dot{fill:#C2FF97;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20b .arc.category17 path{fill:#C2FF97}
+
+.epoch-theme-dark .epoch.category20b .bar.category17{fill:#C2FF97}
+
+.epoch-theme-dark .epoch.category20b div.ref.category18{background-color:#9FD17C}
+
+.epoch-theme-dark .epoch.category20b .category18 .line{stroke:#9FD17C}
+
+.epoch-theme-dark .epoch.category20b .category18 .area,.epoch-theme-dark .epoch.category20b .category18 .dot{fill:#9FD17C;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20b .arc.category18 path{fill:#9FD17C}
+
+.epoch-theme-dark .epoch.category20b .bar.category18{fill:#9FD17C}
+
+.epoch-theme-dark .epoch.category20b div.ref.category19{background-color:#7DA361}
+
+.epoch-theme-dark .epoch.category20b .category19 .line{stroke:#7DA361}
+
+.epoch-theme-dark .epoch.category20b .category19 .area,.epoch-theme-dark .epoch.category20b .category19 .dot{fill:#7DA361;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20b .arc.category19 path{fill:#7DA361}
+
+.epoch-theme-dark .epoch.category20b .bar.category19{fill:#7DA361}
+
+.epoch-theme-dark .epoch.category20b div.ref.category20{background-color:#65854E}
+
+.epoch-theme-dark .epoch.category20b .category20 .line{stroke:#65854E}
+
+.epoch-theme-dark .epoch.category20b .category20 .area,.epoch-theme-dark .epoch.category20b .category20 .dot{fill:#65854E;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20b .arc.category20 path{fill:#65854E}
+
+.epoch-theme-dark .epoch.category20b .bar.category20{fill:#65854E}
+
+.epoch-theme-dark .epoch.category20c div.ref.category1{background-color:#B7BCD1}
+
+.epoch-theme-dark .epoch.category20c .category1 .line{stroke:#B7BCD1}
+
+.epoch-theme-dark .epoch.category20c .category1 .area,.epoch-theme-dark .epoch.category20c .category1 .dot{fill:#B7BCD1;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20c .arc.category1 path{fill:#B7BCD1}
+
+.epoch-theme-dark .epoch.category20c .bar.category1{fill:#B7BCD1}
+
+.epoch-theme-dark .epoch.category20c div.ref.category2{background-color:#979DAD}
+
+.epoch-theme-dark .epoch.category20c .category2 .line{stroke:#979DAD}
+
+.epoch-theme-dark .epoch.category20c .category2 .area,.epoch-theme-dark .epoch.category20c .category2 .dot{fill:#979DAD;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20c .arc.category2 path{fill:#979DAD}
+
+.epoch-theme-dark .epoch.category20c .bar.category2{fill:#979DAD}
+
+.epoch-theme-dark .epoch.category20c div.ref.category3{background-color:#6E717D}
+
+.epoch-theme-dark .epoch.category20c .category3 .line{stroke:#6E717D}
+
+.epoch-theme-dark .epoch.category20c .category3 .area,.epoch-theme-dark .epoch.category20c .category3 .dot{fill:#6E717D;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20c .arc.category3 path{fill:#6E717D}
+
+.epoch-theme-dark .epoch.category20c .bar.category3{fill:#6E717D}
+
+.epoch-theme-dark .epoch.category20c div.ref.category4{background-color:#595C66}
+
+.epoch-theme-dark .epoch.category20c .category4 .line{stroke:#595C66}
+
+.epoch-theme-dark .epoch.category20c .category4 .area,.epoch-theme-dark .epoch.category20c .category4 .dot{fill:#595C66;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20c .arc.category4 path{fill:#595C66}
+
+.epoch-theme-dark .epoch.category20c .bar.category4{fill:#595C66}
+
+.epoch-theme-dark .epoch.category20c div.ref.category5{background-color:#FF857F}
+
+.epoch-theme-dark .epoch.category20c .category5 .line{stroke:#FF857F}
+
+.epoch-theme-dark .epoch.category20c .category5 .area,.epoch-theme-dark .epoch.category20c .category5 .dot{fill:#FF857F;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20c .arc.category5 path{fill:#FF857F}
+
+.epoch-theme-dark .epoch.category20c .bar.category5{fill:#FF857F}
+
+.epoch-theme-dark .epoch.category20c div.ref.category6{background-color:#DE746E}
+
+.epoch-theme-dark .epoch.category20c .category6 .line{stroke:#DE746E}
+
+.epoch-theme-dark .epoch.category20c .category6 .area,.epoch-theme-dark .epoch.category20c .category6 .dot{fill:#DE746E;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20c .arc.category6 path{fill:#DE746E}
+
+.epoch-theme-dark .epoch.category20c .bar.category6{fill:#DE746E}
+
+.epoch-theme-dark .epoch.category20c div.ref.category7{background-color:#B55F5A}
+
+.epoch-theme-dark .epoch.category20c .category7 .line{stroke:#B55F5A}
+
+.epoch-theme-dark .epoch.category20c .category7 .area,.epoch-theme-dark .epoch.category20c .category7 .dot{fill:#B55F5A;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20c .arc.category7 path{fill:#B55F5A}
+
+.epoch-theme-dark .epoch.category20c .bar.category7{fill:#B55F5A}
+
+.epoch-theme-dark .epoch.category20c div.ref.category8{background-color:#964E4B}
+
+.epoch-theme-dark .epoch.category20c .category8 .line{stroke:#964E4B}
+
+.epoch-theme-dark .epoch.category20c .category8 .area,.epoch-theme-dark .epoch.category20c .category8 .dot{fill:#964E4B;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20c .arc.category8 path{fill:#964E4B}
+
+.epoch-theme-dark .epoch.category20c .bar.category8{fill:#964E4B}
+
+.epoch-theme-dark .epoch.category20c div.ref.category9{background-color:#F3DE88}
+
+.epoch-theme-dark .epoch.category20c .category9 .line{stroke:#F3DE88}
+
+.epoch-theme-dark .epoch.category20c .category9 .area,.epoch-theme-dark .epoch.category20c .category9 .dot{fill:#F3DE88;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20c .arc.category9 path{fill:#F3DE88}
+
+.epoch-theme-dark .epoch.category20c .bar.category9{fill:#F3DE88}
+
+.epoch-theme-dark .epoch.category20c div.ref.category10{background-color:#DBC87B}
+
+.epoch-theme-dark .epoch.category20c .category10 .line{stroke:#DBC87B}
+
+.epoch-theme-dark .epoch.category20c .category10 .area,.epoch-theme-dark .epoch.category20c .category10 .dot{fill:#DBC87B;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20c .arc.category10 path{fill:#DBC87B}
+
+.epoch-theme-dark .epoch.category20c .bar.category10{fill:#DBC87B}
+
+.epoch-theme-dark .epoch.category20c div.ref.category11{background-color:#BAAA68}
+
+.epoch-theme-dark .epoch.category20c .category11 .line{stroke:#BAAA68}
+
+.epoch-theme-dark .epoch.category20c .category11 .area,.epoch-theme-dark .epoch.category20c .category11 .dot{fill:#BAAA68;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20c .arc.category11 path{fill:#BAAA68}
+
+.epoch-theme-dark .epoch.category20c .bar.category11{fill:#BAAA68}
+
+.epoch-theme-dark .epoch.category20c div.ref.category12{background-color:#918551}
+
+.epoch-theme-dark .epoch.category20c .category12 .line{stroke:#918551}
+
+.epoch-theme-dark .epoch.category20c .category12 .area,.epoch-theme-dark .epoch.category20c .category12 .dot{fill:#918551;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20c .arc.category12 path{fill:#918551}
+
+.epoch-theme-dark .epoch.category20c .bar.category12{fill:#918551}
+
+.epoch-theme-dark .epoch.category20c div.ref.category13{background-color:#C9935E}
+
+.epoch-theme-dark .epoch.category20c .category13 .line{stroke:#C9935E}
+
+.epoch-theme-dark .epoch.category20c .category13 .area,.epoch-theme-dark .epoch.category20c .category13 .dot{fill:#C9935E;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20c .arc.category13 path{fill:#C9935E}
+
+.epoch-theme-dark .epoch.category20c .bar.category13{fill:#C9935E}
+
+.epoch-theme-dark .epoch.category20c div.ref.category14{background-color:#B58455}
+
+.epoch-theme-dark .epoch.category20c .category14 .line{stroke:#B58455}
+
+.epoch-theme-dark .epoch.category20c .category14 .area,.epoch-theme-dark .epoch.category20c .category14 .dot{fill:#B58455;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20c .arc.category14 path{fill:#B58455}
+
+.epoch-theme-dark .epoch.category20c .bar.category14{fill:#B58455}
+
+.epoch-theme-dark .epoch.category20c div.ref.category15{background-color:#997048}
+
+.epoch-theme-dark .epoch.category20c .category15 .line{stroke:#997048}
+
+.epoch-theme-dark .epoch.category20c .category15 .area,.epoch-theme-dark .epoch.category20c .category15 .dot{fill:#997048;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20c .arc.category15 path{fill:#997048}
+
+.epoch-theme-dark .epoch.category20c .bar.category15{fill:#997048}
+
+.epoch-theme-dark .epoch.category20c div.ref.category16{background-color:#735436}
+
+.epoch-theme-dark .epoch.category20c .category16 .line{stroke:#735436}
+
+.epoch-theme-dark .epoch.category20c .category16 .area,.epoch-theme-dark .epoch.category20c .category16 .dot{fill:#735436;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20c .arc.category16 path{fill:#735436}
+
+.epoch-theme-dark .epoch.category20c .bar.category16{fill:#735436}
+
+.epoch-theme-dark .epoch.category20c div.ref.category17{background-color:#A488FF}
+
+.epoch-theme-dark .epoch.category20c .category17 .line{stroke:#A488FF}
+
+.epoch-theme-dark .epoch.category20c .category17 .area,.epoch-theme-dark .epoch.category20c .category17 .dot{fill:#A488FF;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20c .arc.category17 path{fill:#A488FF}
+
+.epoch-theme-dark .epoch.category20c .bar.category17{fill:#A488FF}
+
+.epoch-theme-dark .epoch.category20c div.ref.category18{background-color:#8670D1}
+
+.epoch-theme-dark .epoch.category20c .category18 .line{stroke:#8670D1}
+
+.epoch-theme-dark .epoch.category20c .category18 .area,.epoch-theme-dark .epoch.category20c .category18 .dot{fill:#8670D1;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20c .arc.category18 path{fill:#8670D1}
+
+.epoch-theme-dark .epoch.category20c .bar.category18{fill:#8670D1}
+
+.epoch-theme-dark .epoch.category20c div.ref.category19{background-color:#705CAD}
+
+.epoch-theme-dark .epoch.category20c .category19 .line{stroke:#705CAD}
+
+.epoch-theme-dark .epoch.category20c .category19 .area,.epoch-theme-dark .epoch.category20c .category19 .dot{fill:#705CAD;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20c .arc.category19 path{fill:#705CAD}
+
+.epoch-theme-dark .epoch.category20c .bar.category19{fill:#705CAD}
+
+.epoch-theme-dark .epoch.category20c div.ref.category20{background-color:#52447F}
+
+.epoch-theme-dark .epoch.category20c .category20 .line{stroke:#52447F}
+
+.epoch-theme-dark .epoch.category20c .category20 .area,.epoch-theme-dark .epoch.category20c .category20 .dot{fill:#52447F;stroke:transparent}
+
+.epoch-theme-dark .epoch.category20c .arc.category20 path{fill:#52447F}
+
+.epoch-theme-dark .epoch.category20c .bar.category20{fill:#52447F}
+


### PR DESCRIPTION
The original line was split up (by script) into a more readable and intuitive format (i.e. one "block" per line) to facilitate reading and modification.

If you notice any issues or discrepancies, please advise for modification.